### PR TITLE
Remove references to AcmeDemoBundle in prod configuration

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -37,8 +37,6 @@ doctrine:
 
     orm:
         auto_generate_proxy_classes: %kernel.debug%
-        mappings:
-            AcmeDemoBundle: ~
 
 # Swiftmailer Configuration
 swiftmailer:

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -16,3 +16,8 @@ zend:
 
 assetic:
     use_controller: true
+
+doctrine:
+  orm:
+      mappings:
+          AcmeDemoBundle: ~

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -1,3 +1,1 @@
-_welcome:
-    resource: "@AcmeDemoBundle/Controller/WelcomeController.php"
-    type:     annotation
+

--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -1,6 +1,10 @@
 _main:
     resource: routing.yml
 
+_welcome:
+    resource: "@AcmeDemoBundle/Controller/WelcomeController.php"
+    type:     annotation
+
 _demo:
     resource: "@AcmeDemoBundle/Controller/DemoController.php"
     type:     annotation


### PR DESCRIPTION
There were references to the AcmeDemoBundle in the configuration files config.yml and routing.yml, which are also loaded in the prod environment. Since the AcmeDemoBundle is only loaded when the dev environment is being used, this was causing issues with the prod environment. I've moved all references of AcmeDemoBundle to the *_dev.yml configuration files to fix this issue. In dev, the AcmeDemoBundle now works as expected. In the prod environment, AcmeDemoBundle does not work (which is expected) however any new bundles created in the Standard Distribution now do not break anymore in prod.
