### PR TITLE
vendor.sh clones the entire history (time and space consuming)

### DIFF
--- a/bin/vendors.sh
+++ b/bin/vendors.sh
@@ -26,7 +26,7 @@ install_git()
     fi
 
     if [ ! -d $INSTALL_DIR ]; then
-        git clone $SOURCE_URL $INSTALL_DIR
+        git clone --depth 1 $SOURCE_URL $INSTALL_DIR
     fi
 
     cd $INSTALL_DIR


### PR DESCRIPTION
I've just added the "--depth 1" parameter to the vendor.sh file in order to accelerate the cloning procedure.

Because we are just working on the main structure, I feel like the full history is not necessary.
