### PR TITLE
Installing the vendors into paths with spaces in name

### DIFF
--- a/bin/vendors.sh
+++ b/bin/vendors.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 DIR=`php -r "echo realpath(dirname(\\$_SERVER['argv'][0]));"`
-VENDOR=$DIR/vendor
-VERSION=`cat $DIR/VERSION`
+VENDOR="$DIR/vendor"
+VERSION=`cat "$DIR/VERSION"`
 
 # initialization
 if [ "$1" = "--reinstall" -o "$2" = "--reinstall" ]; then
@@ -15,7 +15,7 @@ if [ "$1" = "--min" -o "$2" = "--min" ]; then
     CLONE_OPTIONS='--depth 1'
 fi
 
-mkdir -p $VENDOR && cd $VENDOR
+mkdir -p "$VENDOR" && cd "$VENDOR"
 
 ##
 # @param destination directory (e.g. "doctrine")


### PR DESCRIPTION
The vendors.sh created two new directories when the pathname contained a space. This fixes the issue by adding quotes where required.

Example:
havvg@havvgBook:~/Web Development/symfony2-sandbox $ ./bin/vendors.sh
- created ~/Web/
- created ~/Web Development/symfony2-sandbox/Development/

Afterwards calls to the ../bin/\* failed.
