### PR TITLE
Conflicting routes between profiler and custom routes..

### DIFF
--- a/app/config/routing_dev.yml
+++ b/app/config/routing_dev.yml
@@ -1,6 +1,3 @@
-_main:
-    resource: routing.yml
-
 _assetic:
     resource: .
     type:     assetic
@@ -16,3 +13,6 @@ _profiler:
 _configurator:
     resource: "@SymfonyWebConfiguratorBundle/Resources/config/routing/configurator.xml"
     prefix:   /_configurator
+
+_main:
+    resource: routing.yml


### PR DESCRIPTION
This was the easiest fix and I don't know if it was the right one.  Custom routes like /{arg1}/{arg2} conflict with _wdt/token and the javascript file simply calls the custom route and removes the profiler.
