### PR TITLE
Fixed .DS_Store cleanup

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -24,6 +24,10 @@ cp -r VERSION /tmp/Symfony/
 cd /tmp/Symfony
 sudo rm -rf app/cache/* app/logs/* .git*
 chmod 777 app/cache app/logs
+
+# DS_Store cleanup
+find . -name .DS_Store | xargs rm -rf -
+
 cd ..
 # avoid the creation of ._* files
 export COPY_EXTENDED_ATTRIBUTES_DISABLE=true
@@ -83,7 +87,6 @@ find . -name .git | xargs rm -rf -
 find . -name .gitignore | xargs rm -rf -
 find . -name .gitmodules | xargs rm -rf -
 find . -name .svn | xargs rm -rf -
-find . -name .DS_Store | xargs rm -rf -
 
 cd /tmp/
 mv /tmp/vendor /tmp/Symfony/


### PR DESCRIPTION
There we some .DS_Store files on the app dir

The command added to remove the .DS_Store files here:
https://github.com/symfony/symfony-standard/commit/3a2cddb16eefceab62f1b097b073f5456e443acf

won't work because the script at that time is on the vendors dir. it needs a `cd ..` before the command. 
I added it even earlier, so that it removes the file in the "without vendors" build as well.
