### PR TITLE
fix for  "Route "_configurator_home" does not exist." when starting app via app.php

### DIFF
--- a/src/Acme/DemoBundle/Resources/views/Welcome/index.html.twig
+++ b/src/Acme/DemoBundle/Resources/views/Welcome/index.html.twig
@@ -16,7 +16,7 @@
             </div>
             <a class="symfony-button-green" href="http://symfony.com/doc/2.0/quick_tour/index.html">Read the Quick Tour</a>
         </div>
-        {% if app.environment != 'prod' %}
+        {% if app.environment == 'dev' %}
         <div class="block-configure">
             <div class="illustration">
                 <img src="{{ asset('bundles/acmedemo/images/welcome-configure.gif') }}" alt="Configure your appication" />


### PR DESCRIPTION
There are two ways on fixing this one:
- by enabling configuration only in dev environment (provided)
- by including _configuration route into main routing.yml

I'd argue that the first option is better as the configuration just like the toolbar shouldn't be present when running in prod environment.
