### PR TITLE
Change vendors repositories to http

### DIFF
--- a/bin/vendors.sh
+++ b/bin/vendors.sh
@@ -43,54 +43,54 @@ install_git()
 }
 
 # Assetic
-install_git assetic git://github.com/kriswallsmith/assetic.git #v1.0.0alpha1
+install_git assetic http://github.com/kriswallsmith/assetic.git #v1.0.0alpha1
 
 # Symfony
-install_git symfony git://github.com/symfony/symfony.git #v$VERSION
+install_git symfony http://github.com/symfony/symfony.git #v$VERSION
 
 # Update the bootstrap files
 $DIR/bin/build_bootstrap.php
 
 # Doctrine ORM
-install_git doctrine git://github.com/doctrine/doctrine2.git 2.0.3
+install_git doctrine http://github.com/doctrine/doctrine2.git 2.0.3
 
 # Doctrine DBAL
-install_git doctrine-dbal git://github.com/doctrine/dbal.git 2.0.3
+install_git doctrine-dbal http://github.com/doctrine/dbal.git 2.0.3
 
 # Doctrine Common
-install_git doctrine-common git://github.com/doctrine/common.git 2.0.1
+install_git doctrine-common http://github.com/doctrine/common.git 2.0.1
 
 # Swiftmailer
-install_git swiftmailer git://github.com/swiftmailer/swiftmailer.git origin/4.1
+install_git swiftmailer http://github.com/swiftmailer/swiftmailer.git origin/4.1
 
 # Twig
-install_git twig git://github.com/fabpot/Twig.git v1.0.0
+install_git twig http://github.com/fabpot/Twig.git v1.0.0
 
 # Twig Extensions
-install_git twig-extensions git://github.com/fabpot/Twig-extensions.git
+install_git twig-extensions http://github.com/fabpot/Twig-extensions.git
 
 # Zend Framework Log
 mkdir -p zend-log/Zend
 cd zend-log/Zend
-install_git Log git://github.com/symfony/zend-log.git
+install_git Log http://github.com/symfony/zend-log.git
 cd ../..
 
 # SensioFrameworkExtraBundle
 mkdir -p bundles/Sensio/Bundle
 cd bundles/Sensio/Bundle
-install_git FrameworkExtraBundle git://github.com/sensio/SensioFrameworkExtraBundle.git
+install_git FrameworkExtraBundle http://github.com/sensio/SensioFrameworkExtraBundle.git
 cd ../../..
 
 # SecurityExtraBundle
 mkdir -p bundles/JMS
 cd bundles/JMS
-install_git SecurityExtraBundle git://github.com/schmittjoh/SecurityExtraBundle.git
+install_git SecurityExtraBundle http://github.com/schmittjoh/SecurityExtraBundle.git
 cd ../..
 
 # WebConfiguratorBundle
 mkdir -p bundles/Symfony/Bundle
 cd bundles/Symfony/Bundle
-install_git WebConfiguratorBundle git://github.com/symfony/WebConfiguratorBundle.git
+install_git WebConfiguratorBundle http://github.com/symfony/WebConfiguratorBundle.git
 cd ../../..
 
 # Update assets


### PR DESCRIPTION
Changed git:// to http:// . This is a more accesible way to create vendors for people behind a proxy.
