### PR TITLE
[AcmeDemoBundle] Fix css to wrap text

### DIFF
--- a/src/Acme/DemoBundle/Resources/public/css/demo.css
+++ b/src/Acme/DemoBundle/Resources/public/css/demo.css
@@ -122,6 +122,7 @@ ul li
     -webkit-border-radius:      16px;
     border-radius:              16px;
     margin-bottom:              20px;
+    word-wrap:                  break-word;
 }
 
 #symfony-search


### PR DESCRIPTION
Without this CSS fix, the code shown at /demo/secured/login would overflow the container
