### PR TITLE
Add firephp log output by default in dev config

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -15,6 +15,9 @@ monolog:
             type:  stream
             path:  %kernel.logs_dir%/%kernel.environment%.log
             level: debug
+        firephp:
+            type:  firephp
+            level: info
 
 assetic:
     use_controller: true


### PR DESCRIPTION
To me that can be nice, because you can disable the dev toolbar and still have access to the relevant info right there when you need it. Up to you if you think it's a good idea by default or not.
