### PR TITLE
Remove the build_bootstrap and assets install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ distribution. If you still want to use Git, your are on your own.
 Run the following scripts:
 
  * `bin/vendors.sh` (use `--min` if you don't want all the history)
- * `bin/build_bootstrap.php`
- * `app/console assets:install web/`
 
 Configuration
 -------------


### PR DESCRIPTION
Remove the build_bootstrap and assets install commands as they are launch by vendord.sh.
