### PR TITLE
Add default test storage to config_test.yml

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -3,6 +3,8 @@ imports:
 
 framework:
     test: ~
+    session:
+        storage_id: session.storage.filesystem
 
 web_profiler:
     toolbar: false


### PR DESCRIPTION
Overrides the native session storage by default, so that we don't have to override it in the extension (see upcoming PR on symfony/symfony).
