### PR TITLE
vendors.php fix for windows

### DIFF
--- a/bin/vendors.php
+++ b/bin/vendors.php
@@ -49,12 +49,12 @@ foreach (file(__DIR__.'/deps') as $line) {
 
     $installDir = $vendorDir.'/'.$path.'/'.$name;
     if (in_array('--reinstall', $argv)) {
-			if (PHP_OS == 'WINNT') {
-				system('rmdir /S /Q '.realpath($installDir));
-			} else {
-				system('rm -rf '.$installDir);
-			}
+		if (PHP_OS == 'WINNT') {
+			system('rmdir /S /Q '.realpath($installDir));
+		} else {
+			system('rm -rf '.$installDir);
 		}
+	}
     $rev = isset($versions[$name]) ? $versions[$name] : 'origin/HEAD';
 
     echo "> Installing/Updating $name\n";


### PR DESCRIPTION
Fix for windows, where without 'php' first it just tries to open the file instead of executing. Tested on w7 with xampp php.
update: added the equivalent of rm -rf for windows, with realpath() to normalize forward and backslashes. updated the new call to cache:clear.
