### PR TITLE
rm excess slash

### DIFF
--- a/bin/vendors.php
+++ b/bin/vendors.php
@@ -68,7 +68,7 @@ foreach (file(__DIR__.'/deps') as $line) {
 system($rootDir.'/bin/build_bootstrap.php');
 
 // Update assets
-system($rootDir.'/app/console assets:install '.$rootDir.'/web/');
+system($rootDir.'/app/console assets:install '.$rootDir.'/web');
 
 // Remove the cache
 system($rootDir.'/app/console cache:clear --no-warmup');


### PR DESCRIPTION
slash after "/web" is excess

<pre>/var/www/my/stfalcon.com/web//bundles/framework</pre>
