### PR TITLE
Disable CSRF protection in test env

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -3,6 +3,7 @@ imports:
 
 framework:
     test: ~
+    csrf_protection: false
     session:
         storage_id: session.storage.filesystem
 


### PR DESCRIPTION
This is pretty annoying when testing forms with WebTestCase, and I don't see the value in keeping it.
