### PR TITLE
Remove --min option which breaks further vendor-updates.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,16 +30,11 @@ available to install the vendors:
 
     php bin/vendors.php
 
-.. tip::
-
-    You can pass the `--min` option if you don't want all the history. This
-    also makes the installation much faster.
-
 Installation from Git
 ---------------------
 
 We highly recommend you that you download the packaged version of this
-distribution. If you still want to use Git, your are on your own.
+distribution. If you still want to use git, your are on your own.
 
 Run the following commands:
 
@@ -50,7 +45,7 @@ Run the following commands:
 
 .. note::
 
-    Symfony SE does/can not use git submodules as you should not keep the
+    Symfony SE does/can not use git-submodules as you should not keep the
     `.git` directory.
 
 Configuration

--- a/bin/vendors.php
+++ b/bin/vendors.php
@@ -14,12 +14,6 @@ $rootDir = dirname(__DIR__);
 $vendorDir = $rootDir.'/vendor';
 $version = trim(file_get_contents($rootDir.'/VERSION'));
 
-// Initialization
-$cloneOptions = '';
-if (in_array('--min', $argv)) {
-    $cloneOptions = '--depth 1';
-}
-
 if (!is_dir($vendorDir)) {
     mkdir($vendorDir, 0777, true);
 }
@@ -56,7 +50,7 @@ foreach (file(__DIR__.'/deps') as $line) {
     echo "> Installing/Updating $name\n";
 
     if (!is_dir($installDir)) {
-        system(sprintf('git clone %s %s %s', $cloneOptions, $url, $installDir));
+        system(sprintf('git clone %s %s', $url, $installDir));
     }
 
     system(sprintf('cd %s && git fetch origin && git reset --hard %s', $installDir, $rev));


### PR DESCRIPTION
Using the git clone --depth=... is creating a shallow clone. git help clone:
"A shallow repository has a number of limitations (you cannot clone or fetch from it, nor push from nor into it)..."
