### PR TITLE
Enabled the annotations for the validator

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -8,7 +8,7 @@ framework:
     router:          { resource: "%kernel.root_dir%/config/routing.yml" }
     form:            true
     csrf_protection: true
-    validation:      true
+    validation:      { enable_annotations: true }
     templating:      { engines: ['twig'] } #assets_version: SomeVersionScheme
     session:
         default_locale: %locale%


### PR DESCRIPTION
Annotations are encouraged in the SE so I think they should be enabled by default for the validator to avoid some WTF to people trying to use them.
