### PR TITLE
Session lifetime should be configured in php.ini, this value only applies

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -12,7 +12,6 @@ framework:
     templating:      { engines: ['twig'] } #assets_version: SomeVersionScheme
     session:
         default_locale: %locale%
-        lifetime:       3600
         auto_start:     true
 
 # Twig Configuration


### PR DESCRIPTION
Session lifetime should be configured in php.ini, this value only applies to the cookie and is not enforced if the client decides to keep the cookie for more than one hour
