### PR TITLE
Added the charset for the DBAL connection

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -39,6 +39,7 @@ doctrine:
         dbname:   %database_name%
         user:     %database_user%
         password: %database_password%
+        charset:  UTF8
 
     orm:
         auto_generate_proxy_classes: %kernel.debug%


### PR DESCRIPTION
The charset is needed when using MySQL with UTF8 otherwise the `SET NAMES UTF8` query is not performed which breaks the encoding in the database (making it ugly when someone looks at it with PHPMyAdmin)
