### PR TITLE
Using escapeshellarg() instead of quotes to fix paths with spaces

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -82,10 +82,10 @@ foreach (file($rootDir.'/deps') as $line) {
     echo "> Installing/Updating $name\n";
 
     if (!is_dir($installDir)) {
-        system(sprintf('git clone %s %s', $url, escapeshellarg($installDir)));
+        system(sprintf('git clone %s %s', escapeshellarg($url), escapeshellarg($installDir)));
     }
 
-    system(sprintf('cd %s && git fetch origin && git reset --hard %s', escapeshellarg($installDir), $rev));
+    system(sprintf('cd %s && git fetch origin && git reset --hard %s', escapeshellarg($installDir), escapeshellarg($rev)));
 }
 
 // update?


### PR DESCRIPTION
Change from quotes to using escapeshellarg().  Also added escaping to more params.

symfony-standard version of https://github.com/symfony/symfony/pull/1273
