### PR TITLE
Fixed error on bin/vendors update

### DIFF
--- a/deps
+++ b/deps
@@ -13,7 +13,7 @@
 
 [doctrine-dbal]
     git=http://github.com/doctrine/dbal.git
-    version=origin/2.0.5
+    version=2.0.5
 
 [doctrine]
     git=http://github.com/doctrine/doctrine2.git


### PR DESCRIPTION
Version origin/2.0.5 doesn't exist. Error given on bin/vendors update for doctrine-dbal:
`fatal: ambiguous argument 'origin/2.0.5': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions`

This syntax is for branch. What exists is tag 2.0.5.

Anyway, I didn't looked at the code of doctrine-dbal to see if what makes sense is to remove origin from version entry on deps or to put origin/2.0.x.

Best regards,
Luís Sousa
