### PR TITLE
Adding a check for the version of a distribution

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -36,12 +36,12 @@ if (!in_array($command = array_shift($argv), array('install', 'update'))) {
  * Check wether this project is based on the Standard Edition that was
  * shipped with vendors or not.
  */
-if (!is_dir($vendorDir.'/symfony/.git'))
+if (!is_dir($vendorDir.'/symfony/.git') && !in_array('--reinstall', $argv))
 {
     exit(<<<EOF
 Your project seems to be based on a Standard Edition that included vendors.
 
-Try to remove the vendor/ folder and run ./bin/vendors again.
+Try to run ./bin/vendors install --reinstall.
 
 
 EOF


### PR DESCRIPTION
added a way to check wether the project sources were shipped with or without vendors.
