### PR TITLE
Removed the processor for the firephp handler

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -18,7 +18,6 @@ monolog:
         firephp:
             type:  firephp
             level: info
-            processors: [@monolog.processor.introspection]
 
 assetic:
     use_controller: true


### PR DESCRIPTION
Removed the processor for the firephp handler as the way to configure them changed

This is necessary for symfony/symfony#1556
