### PR TITLE
Catch ini parsing errors for deps file, exit w useful error message

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -65,6 +65,9 @@ if ('install' === $command && file_exists($rootDir.'/deps.lock')) {
 
 $newversions = array();
 $deps = parse_ini_file($rootDir.'/deps', true, INI_SCANNER_RAW);
+if (false === $deps) {
+    exit("The deps file is not valid ini syntax. Perhaps missing a trailing newline?\n");
+}
 foreach ($deps as $name => $dep) {
     $dep = array_map('trim', $dep);
 


### PR DESCRIPTION
Figure it'd be useful to exit with a specific error message if the ini parsing for bin/vendors fails
