### PR TITLE
update default yui compressor jar to latest version

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -29,7 +29,7 @@ assetic:
         # closure:
         #     jar: %kernel.root_dir%/java/compiler.jar
         # yui_css:
-        #     jar: %kernel.root_dir%/java/yuicompressor-2.4.2.jar
+        #     jar: %kernel.root_dir%/java/yuicompressor-2.4.6.jar
 
 # Doctrine Configuration
 doctrine:


### PR DESCRIPTION
Since most people will be downloading the latest version of the jar file, I thought it would be easier to have that version as the default commented out version.
