### PR TITLE
Check for SYMFONY_ENV in app/console before defaulting to "dev" env

### DIFF
--- a/app/console
+++ b/app/console
@@ -8,7 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 
 $input = new ArgvInput();
-$env = $input->getParameterOption(array('--env', '-e'), 'dev');
+$env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
 $debug = !$input->hasParameterOption(array('--no-debug', ''));
 
 $kernel = new AppKernel($env, $debug);


### PR DESCRIPTION
@stephaneerard suggested this: https://twitter.com/#!/StephaneErard/status/93696791714861057

Decided to use `SYMFONY_ENV` instead of simply `ENV`, as Rails uses `RAILS_ENV`.

This apparently has nothing to do with Symfony2's code and I don't believe that `app/console` exists in any other repository, so this seemed the likely place for the commit.
