### PR TITLE
allow custom git command when running bin/vendors, e.g. for submodule init and update

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -100,7 +100,13 @@ foreach ($deps as $name => $dep) {
         system(sprintf('git clone %s %s', escapeshellarg($url), escapeshellarg($installDir)));
     }
 
-    system(sprintf('cd %s && git fetch origin && git reset --hard %s', escapeshellarg($installDir), escapeshellarg($rev)));
+    if (isset($dep['git_command'])) {
+        $git_command = ' && git ' . $dep['git_command'] . ' ';
+    } else {
+        $git_command = '';
+    }
+
+    system(sprintf('cd %s && git fetch origin && git reset --hard %s' . $git_command, escapeshellarg($installDir), escapeshellarg($rev)));
 
     if ('update' === $command) {
         ob_start();


### PR DESCRIPTION
Background: some git repositories use submodules to manage associations to other git repositories that they depend on.  This change allows running a git command, specified in the deps file, when a project component gets installed / updated by bin/vendors.

A sample deps file entry, which results in a recursive init and update of the submodules within the doctrine-phpcr-odm repository:

```
[doctrine-phpcr-odm]
    git=git://github.com/doctrine/phpcr-odm.git
    git_command=submodule update --init --recursive
```
