### PR TITLE
Removing shebang from bin/vendors

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -115,7 +115,7 @@ if ('update' === $command) {
 }
 
 // php on windows can't use the shebang line from system()
-$interpreter = PHP_OS == 'WINNT' ? 'php.exe' : '';
+$interpreter = PHP_OS == 'WINNT' ? 'php.exe' : 'php';
 
 // Update the bootstrap files
 system(sprintf('%s %s', $interpreter, escapeshellarg($rootDir.'/vendor/bundles/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php')));


### PR DESCRIPTION
Hey guys!

This forces the commands called internally by `bin/vendors` to use the PHP executable. I believe this is just as dependable as allowing the script itself to find the right PHP executable (i.e. both will work/fail entirely based on whether or not the php executable is in the path).

What this helps is an edge case where the user doesn't have +x permissions on any script that's called. We saw this as a ticket against capifony - bin/vendors was failing on deploy.

Thanks!
