### PR TITLE
Bin vendor root dir specify

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -120,7 +120,7 @@ if ('update' === $command) {
 $interpreter = PHP_OS == 'WINNT' ? 'php.exe' : '';
 
 // Update the bootstrap files
-system(sprintf('%s %s', $interpreter, escapeshellarg($rootDir.'/vendor/bundles/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php')));
+system(sprintf('%s %s %s', $interpreter, escapeshellarg($rootDir.'/vendor/bundles/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php'), $rootDir));
 
 // Update assets
 system(sprintf('%s %s assets:install %s', $interpreter, escapeshellarg($rootDir.'/app/console'), escapeshellarg($rootDir.'/web/')));


### PR DESCRIPTION
Hey guys!

Explicitly passing the project's root dir to the build_bootstrap.php script

This takes advantage of a recent change in the SensioDistributionBundle which allows this. A specific situation this addresses is when the `vendor` dir is symlinked, and the build_bootstrap.php script mistakenly places the bootstrap.php.cache in ../app of the vendor dir's real location (instead of actually inside the project).

See: https://github.com/sensio/SensioDistributionBundle/pull/9

Thanks!
