### PR TITLE
Symbolic vendor 2.0

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -120,7 +120,7 @@ if ('update' === $command) {
 $interpreter = PHP_OS == 'WINNT' ? 'php.exe' : '';
 
 // Update the bootstrap files
-system(sprintf('%s %s', $interpreter, escapeshellarg($rootDir.'/vendor/bundles/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php')));
+system(sprintf('%s %s %s', $interpreter, escapeshellarg($rootDir.'/vendor/bundles/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php'), escapeshellarg($rootDir)));
 
 // Update assets
 system(sprintf('%s %s assets:install %s', $interpreter, escapeshellarg($rootDir.'/app/console'), escapeshellarg($rootDir.'/web/')));


### PR DESCRIPTION
Fix the path of the generated bootstrap.php.cache when using symbolic links

In SensioDistributionBundle, build_bootstrap.php uses its own path to determine
where it should genereate bootstrap.path.cache:
`__DIR__.'/../../../../../../../'.'app/bootstrap.php.cache'`

If your "vendor" path is just a symlink (this is the case if you use capifony
for example), this will generate bootstrap.php.cache in the wrong path.

This fix adds the root path as argument to build_bootstrap (based on the path of
bin/vendors).
