### PR TITLE
Hint for the user on how to point to java executable in config

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -25,6 +25,7 @@ twig:
 assetic:
     debug:          %kernel.debug%
     use_controller: false
+    # java: /usr/bin/java
     filters:
         cssrewrite: ~
         # closure:


### PR DESCRIPTION
consider adding hint for the user on how to specify path to java executable.
Ran into problems on my windows machine with unclear error message:
    [RuntimeException]
    The system cannot find the path specified.
when tried to clear cache or publish assets
