### PR TITLE
Updated bin/vendors to use `realpath` when determining root directory

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -12,7 +12,7 @@
 
 set_time_limit(0);
 
-$rootDir = dirname(__DIR__);
+$rootDir = dirname(realpath(__DIR__));
 $vendorDir = $rootDir.'/vendor';
 
 array_shift($argv);


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: symfony/symfony#2556

This resolves an issue with following symlinks on a WINNT system when installing vendors.
