### PR TITLE
bin/vendors: break if a bundle has local modifications

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -102,6 +102,10 @@ foreach ($deps as $name => $dep) {
         system(sprintf('git clone %s %s', escapeshellarg($url), escapeshellarg($installDir)));
     }
 
+    $status = system(sprintf('cd %s && git status --porcelain', escapeshellarg($installDir)));
+    if (!empty($status)) {
+      exit("$name has local modifications. Will not proceed without --force.\n");
+    }
     system(sprintf('cd %s && git fetch origin && git reset --hard %s', escapeshellarg($installDir), escapeshellarg($rev)));
 
     if ('update' === $command) {


### PR DESCRIPTION
I'm often developing several Symfony2 bundles at once. I have them all
set up as deps for a single Symfony2 application, and I point Netbeans
at the base of the Symfony2 directory.

Since each [sub]dir in vendor/ is a complete git repository, after
making a bunch of changes I can then dive into each dir and commit/push
as necessary.

If I accidentally run "bin/vendors install" while I have un-pushed
changes, they're blown away by the "git reset --hard" in bin/vendors.
This patch proposes to make the script more cautious, assuming that
local modifications should never be blown away. Note that "--force" is
unimplemented, this is just one idea.

Also see my recent post about same to the symfony-devs mailing list.
