### PR TITLE
Fixes welcome page links

### DIFF
--- a/src/Acme/DemoBundle/Resources/views/Welcome/index.html.twig
+++ b/src/Acme/DemoBundle/Resources/views/Welcome/index.html.twig
@@ -14,7 +14,7 @@
             <div class="illustration">
                 <img src="{{ asset('bundles/acmedemo/images/welcome-quick-tour.gif') }}" alt="Quick tour" />
             </div>
-            <a class="symfony-button-green" href="http://symfony.com/doc/2.0/quick_tour/index.html">Read the Quick Tour</a>
+            <a class="symfony-button-green" href="http://symfony.com/doc/current/quick_tour/index.html">Read the Quick Tour</a>
         </div>
         {% if app.environment == 'dev' %}
             <div class="block-configure">
@@ -36,15 +36,15 @@
         <div class="block-documentation">
             <ul>
                 <li><strong>Documentation</strong></li>
-                <li><a href="http://symfony.com/doc/2.0/book/index.html">The book</a></li>
-                <li><a href="http://symfony.com/doc/2.0/reference/index.html">The cookbook</a></li>
-                <li><a href="http://symfony.com/doc/2.0/glossary/index.html">Glossary</a></li>
+                <li><a href="http://symfony.com/doc/current/book/index.html">The book</a></li>
+                <li><a href="http://symfony.com/doc/current/cookbook/index.html">The cookbook</a></li>
+                <li><a href="http://symfony.com/doc/current/glossary.html">Glossary</a></li>
             </ul>
         </div>
         <div class="block-documentation-more">
             <ul>
                 <li>&nbsp;</li>
-                <li><a href="http://symfony.com/doc/2.0/contributing/index.html">Contributing</a></li>
+                <li><a href="http://symfony.com/doc/current/contributing/index.html">Contributing</a></li>
                 <li><a href="http://trainings.sensiolabs.com">Trainings</a></li>
                 <li><a href="http://books.sensiolabs.com">Books</a></li>
             </ul>
@@ -55,8 +55,8 @@
                 <li><a href="http://symfony.com/irc">IRC channel</a>
                 <li><a href="http://symfony.com/mailing-lists">Mailing lists</a></li>
                 <li><a href="http://forum.symfony-project.org">Forum</a></li>
-                <li><a href="http://symfony.com/doc/2.0/contributing/index.html">How to be involved</a></li>
-                <li><a href="http://symfony.com/doc/2.0/contributing/index.html">Contributing</a></li>
+                <li><a href="http://symfony.com/doc/current/contributing/index.html">How to be involved</a></li>
+                <li><a href="http://symfony.com/doc/current/contributing/index.html">Contributing</a></li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
The AcmeBundle welcome page contains broken links, in particular the glossary link.

This PR fixes this link and updates other reference links to point to the current doc version
