### PR TITLE
moved ControllerListener to be consistent with FrameworkBundle

### DIFF
--- a/src/Acme/DemoBundle/EventListener/ControllerListener.php
+++ b/src/Acme/DemoBundle/EventListener/ControllerListener.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Acme\DemoBundle;
+namespace Acme\DemoBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpKernel\HttpKernelInterface;

--- a/src/Acme/DemoBundle/Resources/config/services.xml
+++ b/src/Acme/DemoBundle/Resources/config/services.xml
@@ -10,7 +10,7 @@
             <argument type="service" id="twig.loader" />
         </service>
 
-        <service id="acme.demo.listener" class="Acme\DemoBundle\ControllerListener">
+        <service id="acme.demo.listener" class="Acme\DemoBundle\EventListener\ControllerListener">
             <tag name="kernel.event_listener" event="kernel.controller" method="onKernelController" />
             <argument type="service" id="twig.extension.acme.demo" />
         </service>


### PR DESCRIPTION
In `FrameworkBundle`, all the listeners are part of a `EventListener` subnamespace of the Bundle namespace. This PR do the same for the `ControllerListener` of the `DemoBundle`.
