### PR TITLE
add vendor/bundles to namespace fallback

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -6,8 +6,6 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 $loader = new UniversalClassLoader();
 $loader->registerNamespaces(array(
     'Symfony'          => array(__DIR__.'/../vendor/symfony/src', __DIR__.'/../vendor/bundles'),
-    'Sensio'           => __DIR__.'/../vendor/bundles',
-    'JMS'              => __DIR__.'/../vendor/bundles',
     'Doctrine\\Common' => __DIR__.'/../vendor/doctrine-common/lib',
     'Doctrine\\DBAL'   => __DIR__.'/../vendor/doctrine-dbal/lib',
     'Doctrine'         => __DIR__.'/../vendor/doctrine/lib',
@@ -29,6 +27,7 @@ if (!function_exists('intl_get_error_code')) {
 
 $loader->registerNamespaceFallbacks(array(
     __DIR__.'/../src',
+    __DIR__.'/../vendor/bundles',
 ));
 $loader->register();
 


### PR DESCRIPTION
Having this entry drops the step of adding a new bundles or bundle vendors namespace following the conventions.
