### PR TITLE
updated bin/vendor to install assets as symlinks by default

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -127,7 +127,7 @@ $interpreter = defined('PHP_WINDOWS_VERSION_BUILD') ? 'php.exe' : '';
 system(sprintf('%s %s %s', $interpreter, escapeshellarg($rootDir.'/vendor/bundles/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php'), escapeshellarg($rootDir)));
 
 // Update assets
-system(sprintf('%s %s assets:install %s', $interpreter, escapeshellarg($rootDir.'/app/console'), escapeshellarg($rootDir.'/web/')));
+system(sprintf('%s %s assets:install %s%s', $interpreter, escapeshellarg($rootDir.'/app/console'), PHP_OS != 'WINNT' ? '--symlink ' : '', escapeshellarg($rootDir.'/web/')));
 
 // Remove the cache
 system(sprintf('%s %s cache:clear --no-warmup', $interpreter, escapeshellarg($rootDir.'/app/console')));


### PR DESCRIPTION
I noticed that bin/vendor overwrites my previously created asset symlinks so here is a patch that uses symlinks on systems where it's available.
