### PR TITLE
bin/vendors: speed up: fetch only when necessary

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -106,6 +106,10 @@ foreach ($deps as $name => $dep) {
     if (!empty($status)) {
         exit(sprintf('"%s" has local modifications. Please revert or commit/push them before running this command again.', $name));
     }
+    $current_rev = system(sprintf('cd %s && git rev-list --max-count=1 HEAD', escapeshellarg($installDir)));
+    if ($current_rev === $rev) {
+        continue;
+    }
 
     system(sprintf('cd %s && git fetch origin && git reset --hard %s', escapeshellarg($installDir), escapeshellarg($rev)));
 


### PR DESCRIPTION
If a bundle's HEAD is already at the version specified in deps or
deps.lock, don't fetch more commits from upstream.

This performance improvement only helps when the version specified is an
SHA-1 checksum (as opposed to a branch or tag name), but that turns out
to be quite often (especially if update/deps.lock is used).

This does not handle the case where upstream contains modified history
(e.g. missing commits), but neither does the rest of bin/vendors.
