### PR TITLE
Using PHP_EOL constant for displayed messages

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -31,7 +31,7 @@ EOF
 }
 
 if (!in_array($command = array_shift($argv), array('install', 'update', 'lock'))) {
-    exit(sprintf("Command \"%s\" does not exist.\n", $command));
+    exit(sprintf('Command "%s" does not exist.', $command).PHP_EOL);
 }
 
 /*
@@ -59,7 +59,7 @@ if ('install' === $command && file_exists($rootDir.'/deps.lock')) {
     foreach (file($rootDir.'/deps.lock', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
         $parts = array_values(array_filter(explode(' ', $line)));
         if (2 !== count($parts)) {
-            exit(sprintf('The deps version file is not valid (near "%s")', $line));
+            exit(sprintf('The deps version file is not valid (near "%s")', $line).PHP_EOL);
         }
         $versions[$parts[0]] = $parts[1];
     }
@@ -68,7 +68,7 @@ if ('install' === $command && file_exists($rootDir.'/deps.lock')) {
 $newversions = array();
 $deps = parse_ini_file($rootDir.'/deps', true, INI_SCANNER_RAW);
 if (false === $deps) {
-    exit("The deps file is not valid ini syntax. Perhaps missing a trailing newline?\n");
+    exit('The deps file is not valid ini syntax. Perhaps missing a trailing newline?'.PHP_EOL);
 }
 foreach ($deps as $name => $dep) {
     $dep = array_map('trim', $dep);
@@ -84,11 +84,11 @@ foreach ($deps as $name => $dep) {
     }
 
     if ('install' === $command || 'update' === $command) {
-        echo "> Installing/Updating $name\n";
+        echo '> Installing/Updating '.$name.PHP_EOL;
 
         // url
         if (!isset($dep['git'])) {
-            exit(sprintf('The "git" value for the "%s" dependency must be set.', $name));
+            exit(sprintf('The "git" value for the "%s" dependency must be set.', $name).PHP_EOL);
         }
         $url = $dep['git'];
 
@@ -105,7 +105,7 @@ foreach ($deps as $name => $dep) {
 
         $status = system(sprintf('cd %s && git status --porcelain', escapeshellarg($installDir)));
         if (!empty($status)) {
-            exit(sprintf('"%s" has local modifications. Please revert or commit/push them before running this command again.', $name));
+            exit(sprintf('"%s" has local modifications. Please revert or commit/push them before running this command again.', $name).PHP_EOL);
         }
         $current_rev = system(sprintf('cd %s && git rev-list --max-count=1 HEAD', escapeshellarg($installDir)));
         if ($current_rev === $rev) {
@@ -124,7 +124,7 @@ foreach ($deps as $name => $dep) {
 
 // update?
 if ('update' === $command || 'lock' === $command) {
-    echo "> Updating deps.lock\n";
+    echo '> Updating deps.lock'.PHP_EOL;
 
     file_put_contents($rootDir.'/deps.lock', implode("\n", $newversions));
 }


### PR DESCRIPTION
Using PHP_EOL constant for displayed messages on vendors script.
Added some missing new lines, to obtain cleaner error messages.
