### PR TITLE
Fix bin/vendors update command on Ubuntu 11.10

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -130,7 +130,7 @@ if ('update' === $command || 'lock' === $command) {
 }
 
 // php on windows can't use the shebang line from system()
-$interpreter = defined('PHP_WINDOWS_VERSION_BUILD') ? 'php.exe' : '';
+$interpreter = defined('PHP_WINDOWS_VERSION_BUILD') ? 'php.exe' : '/usr/bin/env php';
 
 // Update the bootstrap files
 system(sprintf('%s %s %s', $interpreter, escapeshellarg($rootDir.'/vendor/bundles/Sensio/Bundle/DistributionBundle/Resources/bin/build_bootstrap.php'), escapeshellarg($rootDir)));


### PR DESCRIPTION
Hello,

It seems on my Ubuntu 11.10 install the command 'bin/vendors update' won't work as the 'build_boostrap.php' file will fail to load.
I don't know if it's only my case or others have issues as well.

What do you think? Could this make its way to the distribution?
