### PR TITLE
add name-rev trying to retrieve a nice version

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -118,7 +118,19 @@ foreach ($deps as $name => $dep) {
     if ('update' === $command || 'lock' === $command) {
         ob_start();
         system(sprintf('cd %s && git log -n 1 --format=%%H', escapeshellarg($installDir)));
-        $newversions[] = trim($name.' '.ob_get_clean());
+        $newversion = trim(ob_get_clean());
+
+        ob_start();
+        system(sprintf('cd %s && git name-rev --tags --name-only %s', escapeshellarg($installDir), $newversion));
+        // remove trailing ^0 from tags, those are the tags themselves
+        $niceversion = preg_replace('/\^0$/', '', trim(ob_get_clean()));
+
+        // undefined is returned in case no name-rev could be found
+        if ('undefined' !== $niceversion) {
+            $newversions[] = $name.' '.$niceversion;
+        } else {
+            $newversions[] = $name.' '.$newversion;
+        }
     }
 }
 


### PR DESCRIPTION
This will render tag names rather than commit hashes in `deps.lock` file, where possible.

An example `deps.lock` generated:

``` plain
symfony v2.0.9
twig v1.5.1
monolog 1.0.2
doctrine-common 2.1.4
swiftmailer v4.1.5
assetic v1.0.2
twig-extensions a05ab5ed18a51ae45f3dcc2d0c4ec9b3a6386987
metadata 1.0.0
SensioFrameworkExtraBundle 1c7e92f466d11f83130b0c1271f44d067a2c3b31
SensioDistributionBundle 20b66a408084ad8752f98e50f10533f5245310bf
SensioGeneratorBundle dd37fc4487bc09ac01bdcf89e0ff4ee4484b7fab
AsseticBundle v1.0.1
phing 1fd92c78f14a02b3e1cd9c59c7a08b4cab532d33
propel 77a7262d5234fb05ca71922d70bb7476ec0d3a9b
PropelBundle 654ba24db2413fc19cc0f99b8eb0d695705368b8
FOSUserBundle 7688e1edb2ec645b0ca3c060df1cb2073bf1c9cc
gherkin v1.1.4
behat v2.2.5
BehatBundle 4062918f3db5641ea70cd5bd4d78be4646b2b7b1
mink v1.3.2
MinkBundle 788e4a170ab037bf810a26d2b25bfdb7b496df66
Geocoder b1b33e8ec2459c24a31a05e79a0e5833aa27ac8c
GeocodableBehavior efc5426c6fe2eb9dda22e8f43e51261752d6f8ba
Gaufrette ed24a3cd6a322019f0bef6d79873686ba96b8278
```
