### PR TITLE
add a newline at eof in deps.lock

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -138,7 +138,7 @@ foreach ($deps as $name => $dep) {
 if ('update' === $command || 'lock' === $command) {
     echo '> Updating deps.lock'.PHP_EOL;
 
-    file_put_contents($rootDir.'/deps.lock', implode("\n", $newversions));
+    file_put_contents($rootDir.'/deps.lock', implode("\n", $newversions)."\n");
 }
 
 // php on windows can't use the shebang line from system()


### PR DESCRIPTION
Clean up the generated diff from update/lock command.
## Example: adding new vendors
### Prior this change

``` diff
diff --git a/deps.lock b/deps.lock
index e517dc2..5ac0b78 100644
--- a/deps.lock
+++ b/deps.lock
@@ -25,4 +25,6 @@
 GeocodableBehavior efc5426c6fe2eb9dda22e8f43e51261752d6f8ba
 Gaufrette ed24a3cd6a322019f0bef6d79873686ba96b8278
 TwitterBootstrap 11f72f6aa22c9d2daa9a95846e6c786afd7bc3e1
-WebProfilerExtraBundle debdd1456d52763d79c3f737b82ba4f47273554b
\ No newline at end of file
+WebProfilerExtraBundle debdd1456d52763d79c3f737b82ba4f47273554b
+KnpMenu 99165266045f9f3945e9e966f5d98e47cf99d10d
+KnpMenuBundle 3a90f963eb4414d1dea412b72e924e0087c75766
\ No newline at end of file
```
### Change applied

``` diff
diff --git a/deps.lock b/deps.lock
index ee01809..e2254b3 100644
--- a/deps.lock
+++ b/deps.lock
@@ -26,3 +26,5 @@
 Gaufrette ed24a3cd6a322019f0bef6d79873686ba96b8278
 TwitterBootstrap 11f72f6aa22c9d2daa9a95846e6c786afd7bc3e1
 WebProfilerExtraBundle debdd1456d52763d79c3f737b82ba4f47273554b
+KnpMenu 99165266045f9f3945e9e966f5d98e47cf99d10d
+KnpMenuBundle 3a90f963eb4414d1dea412b72e924e0087c75766
```
