### PR TITLE
change protocol of deps repositories, http -> https

### DIFF
--- a/deps
+++ b/deps
@@ -1,77 +1,77 @@
 [symfony]
-    git=http://github.com/symfony/symfony.git
+    git=https://github.com/symfony/symfony.git
 
 [twig]
-    git=http://github.com/fabpot/Twig.git
+    git=https://github.com/fabpot/Twig.git
     version=origin/master
 
 [monolog]
-    git=http://github.com/Seldaek/monolog.git
+    git=https://github.com/Seldaek/monolog.git
     version=1.0.2
 
 [doctrine-common]
-    git=http://github.com/doctrine/common.git
+    git=https://github.com/doctrine/common.git
     version=origin/master
 
 [doctrine-dbal]
-    git=http://github.com/doctrine/dbal.git
+    git=https://github.com/doctrine/dbal.git
     version=origin/master
 
 [doctrine]
-    git=http://github.com/doctrine/doctrine2.git
+    git=https://github.com/doctrine/doctrine2.git
     version=origin/master
 
 [swiftmailer]
-    git=http://github.com/swiftmailer/swiftmailer.git
+    git=https://github.com/swiftmailer/swiftmailer.git
     version=v4.1.5
 
 [assetic]
-    git=http://github.com/kriswallsmith/assetic.git
+    git=https://github.com/kriswallsmith/assetic.git
     version=v1.0.2
 
 [twig-extensions]
-    git=http://github.com/fabpot/Twig-extensions.git
+    git=https://github.com/fabpot/Twig-extensions.git
 
 [metadata]
-    git=http://github.com/schmittjoh/metadata.git
+    git=https://github.com/schmittjoh/metadata.git
     version=1.1.0
 
 [SensioFrameworkExtraBundle]
-    git=http://github.com/sensio/SensioFrameworkExtraBundle.git
+    git=https://github.com/sensio/SensioFrameworkExtraBundle.git
     target=/bundles/Sensio/Bundle/FrameworkExtraBundle
     version=origin/master
 
 [JMSSecurityExtraBundle]
-    git=http://github.com/schmittjoh/JMSSecurityExtraBundle.git
+    git=https://github.com/schmittjoh/JMSSecurityExtraBundle.git
     target=/bundles/JMS/SecurityExtraBundle
     version=origin/1.0.x
 
 [SensioDistributionBundle]
-    git=http://github.com/sensio/SensioDistributionBundle.git
+    git=https://github.com/sensio/SensioDistributionBundle.git
     target=/bundles/Sensio/Bundle/DistributionBundle
     version=origin/master
 
 [SensioGeneratorBundle]
-    git=http://github.com/sensio/SensioGeneratorBundle.git
+    git=https://github.com/sensio/SensioGeneratorBundle.git
     target=/bundles/Sensio/Bundle/GeneratorBundle
     version=origin/master
 
 [AsseticBundle]
-    git=http://github.com/symfony/AsseticBundle.git
+    git=https://github.com/symfony/AsseticBundle.git
     target=/bundles/Symfony/Bundle/AsseticBundle
     version=origin/master
 
 [DoctrineBundle]
-    git=http://github.com/doctrine/DoctrineBundle.git
+    git=https://github.com/doctrine/DoctrineBundle.git
     target=/bundles/Doctrine/Bundle/DoctrineBundle
     version=origin/master
 
 [SwiftmailerBundle]
-    git=http://github.com/symfony/SwiftmailerBundle.git
+    git=https://github.com/symfony/SwiftmailerBundle.git
     target=/bundles/Symfony/Bundle/SwiftmailerBundle
     version=origin/master
 
 [MonologBundle]
-    git=http://github.com/symfony/MonologBundle.git
+    git=https://github.com/symfony/MonologBundle.git
     target=/bundles/Symfony/Bundle/MonologBundle
     version=origin/master


### PR DESCRIPTION
Is there any reason for using http instead od https ? Github always gives repository url with https.

It would be nothing wrong with this for me but today i headed problem with executing  php bin/vendors install with success.

Github seems to block cloning of symfony repository (while "php bin/vendors install") after about ~35%
Then you are blacklisted for github and cloning through http is not possible anymore. Tested on 3 different ips.

They are trying to prevent DDoS attacks.
see: https://status.github.com/
