### PR TITLE
Updated to add a rename of the origin URL, this allows people to easily ...

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -112,7 +112,7 @@ foreach ($deps as $name => $dep) {
             continue;
         }
 
-        system(sprintf('cd %s && git fetch origin && git reset --hard %s', escapeshellarg($installDir), escapeshellarg($rev)));
+        system(sprintf('cd %s && git remote set-url origin %s && git fetch origin && git reset --hard %s', escapeshellarg($installDir), escapeshellarg($url), escapeshellarg($rev)));
     }
 
     if ('update' === $command || 'lock' === $command) {


### PR DESCRIPTION
...change the URL in their deps file, without a full reinstall.

This is especially useful, when applying temporary fixes, and other applications. One can fork the repo, commit the fix to one's repository, then pull from that as well.
