### PR TITLE
Disable debug in prod environment

### DIFF
--- a/app/console
+++ b/app/console
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Input\ArgvInput;
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
-$debug = !$input->hasParameterOption(array('--no-debug', '')) && $env !== 'prod';
+$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(array('--no-debug', '')) && $env !== 'prod';
 
 $kernel = new AppKernel($env, $debug);
 $application = new Application($kernel);


### PR DESCRIPTION
Just an idea, but I think it would reflect the app/app_dev model a bit better.
