### PR TITLE
bin/vendors: Exiting early? Return nonzero status.

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -17,7 +17,7 @@ $vendorDir = $rootDir.'/vendor';
 
 array_shift($argv);
 if (!isset($argv[0])) {
-    exit(<<<EOF
+    echo(<<<EOF
 Symfony2 vendors script management.
 
 Specify a command to run:
@@ -29,10 +29,12 @@ Specify a command to run:
 
 EOF
     );
+    exit(1);
 }
 
 if (!in_array($command = array_shift($argv), array('install', 'update', 'lock'))) {
-    exit(sprintf('Command "%s" does not exist.', $command).PHP_EOL);
+    echo(sprintf('Command "%s" does not exist.', $command).PHP_EOL);
+    exit(1);
 }
 
 /*
@@ -40,7 +42,7 @@ if (!in_array($command = array_shift($argv), array('install', 'update', 'lock'))
  * shipped with vendors or not.
  */
 if (is_dir($vendorDir.'/symfony') && !is_dir($vendorDir.'/symfony/.git') && !in_array('--reinstall', $argv)) {
-    exit(<<<EOF
+    echo(<<<EOF
 Your project seems to be based on a Standard Edition that includes vendors.
 
 Try to run ./bin/vendors install --reinstall
@@ -48,6 +50,7 @@ Try to run ./bin/vendors install --reinstall
 
 EOF
     );
+    exit(1);
 }
 
 if (!is_dir($vendorDir)) {
@@ -60,7 +63,8 @@ if ('install' === $command && file_exists($rootDir.'/deps.lock')) {
     foreach (file($rootDir.'/deps.lock', FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) as $line) {
         $parts = array_values(array_filter(explode(' ', $line)));
         if (2 !== count($parts)) {
-            exit(sprintf('The deps version file is not valid (near "%s")', $line).PHP_EOL);
+            echo(sprintf('The deps version file is not valid (near "%s")', $line).PHP_EOL);
+            exit(1);
         }
         $versions[$parts[0]] = $parts[1];
     }
@@ -69,7 +73,8 @@ if ('install' === $command && file_exists($rootDir.'/deps.lock')) {
 $newversions = array();
 $deps = parse_ini_file($rootDir.'/deps', true, INI_SCANNER_RAW);
 if (false === $deps) {
-    exit('The deps file is not valid ini syntax. Perhaps missing a trailing newline?'.PHP_EOL);
+    echo('The deps file is not valid ini syntax. Perhaps missing a trailing newline?'.PHP_EOL);
+    exit(1);
 }
 foreach ($deps as $name => $dep) {
     $dep = array_map('trim', $dep);
@@ -89,7 +94,8 @@ foreach ($deps as $name => $dep) {
 
         // url
         if (!isset($dep['git'])) {
-            exit(sprintf('The "git" value for the "%s" dependency must be set.', $name).PHP_EOL);
+            echo(sprintf('The "git" value for the "%s" dependency must be set.', $name).PHP_EOL);
+            exit(1);
         }
         $url = $dep['git'];
 
@@ -106,7 +112,8 @@ foreach ($deps as $name => $dep) {
 
         $status = system(sprintf('cd %s && git status --porcelain', escapeshellarg($installDir)));
         if (!empty($status)) {
-            exit(sprintf('"%s" has local modifications. Please revert or commit/push them before running this command again.', $name).PHP_EOL);
+            echo(sprintf('"%s" has local modifications. Please revert or commit/push them before running this command again.', $name).PHP_EOL);
+            exit(1);
         }
         $current_rev = system(sprintf('cd %s && git rev-list --max-count=1 HEAD', escapeshellarg($installDir)));
         if ($current_rev === $rev) {


### PR DESCRIPTION
I currently use bin/vendors in several automated build scripts. This
makes it easier for calling scripts to reliably recognize when
bin/vendors exits early.

I know bin/vendors is going away, but until symfony2 2.1 is
released, I'll probably still be using it.
