### PR TITLE
added JMSDiExtraBundle to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The Symfony Standard Edition comes pre-configured with the following bundles:
   ([documentation](http://symfony.com/doc/2.0/cookbook/assetic/asset_management.html))
 * **JMSSecurityExtraBundle** - Allows security to be added via annotations
   ([documentation](http://symfony.com/doc/current/bundles/JMSSecurityExtraBundle/index.html))
+* **JMSDiExtraBundle** - Adds more powerful dependency injection features 
 * **WebProfilerBundle** (in dev/test env) - Adds profiling functionality and
   the web debug toolbar
 * **SensioDistributionBundle** (in dev/test env) - Adds functionality for configuring


### PR DESCRIPTION
This still needs documentation

I see that it's located http://jmsyst.com/bundles/JMSDiExtraBundle and should be ported to Symfony.com's docs.
