### PR TITLE
[2.0] bin/vendors: detect repo url change

### DIFF
--- a/bin/vendors
+++ b/bin/vendors
@@ -82,6 +82,7 @@ foreach ($deps as $name => $dep) {
         } else {
             system(sprintf('rm -rf %s', escapeshellarg($installDir)));
         }
+        clearstatcache();
     }
 
     if ('install' === $command || 'update' === $command) {
@@ -103,6 +104,7 @@ foreach ($deps as $name => $dep) {
                 } else {
                     system(sprintf('rm -rf %s', escapeshellarg($installDir)));
                 }
+                clearstatcache();
             }
         }
 


### PR DESCRIPTION
For performance, our continuous integration server runs "bin/vendors update" instead of "bin/vendors install". This patch allows the script to detect a repo url change in "deps", e.g., switching from an upstream repo to a fork, or vice-versa.
