### PR TITLE
[2.0] Prevent access to app_dev.php through proxy

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -6,10 +6,13 @@
 
 // this check prevents access to debug front controllers that are deployed by accident to production servers.
 // feel free to remove this, extend it, or make something more sophisticated.
-if (!in_array(@$_SERVER['REMOTE_ADDR'], array(
-    '127.0.0.1',
-    '::1',
-))) {
+if (isset($_SERVER['HTTP_CLIENT_IP'])
+    || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
+    || !in_array(@$_SERVER['REMOTE_ADDR'], array(
+        '127.0.0.1',
+        '::1',
+    ))
+) {
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }


### PR DESCRIPTION
Proxies are sometimes on the same machine as the webserver, so they will gain access to app_dev.php, as they have a localhost IP.

That makes app_dev.php accessible by default in such setups.

This commit disallows access to app_dev.php if proxy headers are present.
