### PR TITLE
Checked .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@ app/bootstrap.php.cache
 app/cache/*
 app/logs/*
 build/
-vendor/
+vendor
 composer.phar


### PR DESCRIPTION
vendor/ point in gitignore is only excluding files inside vendor as a folder.
But, as vendor directory is very heavy, when developer has many repositories maybe want to have only one vendor and in all repositories only a soft link.

So, with this commit, vendor is excluded as everything ( file, folder )
