### PR TITLE
Added description to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "symfony/framework-standard-edition",
+    "description": "The \"Symfony Standard Edition\" distribution",
     "autoload": {
         "psr-0": { "": "src/" }
     },


### PR DESCRIPTION
This PR "fixes" the composer.json validation.

Before:
`$ php composer.phar validate
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
description : is missing and it is required`

After:
`$ php composer.phar validate
./composer.json is valid`
