### PR TITLE
Allow renaming of "app" directory without breaking requirements checking

### DIFF
--- a/app/SymfonyRequirements.php
+++ b/app/SymfonyRequirements.php
@@ -392,16 +392,17 @@ class SymfonyRequirements extends RequirementCollection
                 'Then run "<strong>php composer.phar install</strong>" to install them.'
         );
 
+        $baseDir = basename(__DIR__);
         $this->addRequirement(
-            is_writable(__DIR__.'/../app/cache'),
-            'app/cache/ directory must be writable',
-            'Change the permissions of the "<strong>app/cache/</strong>" directory so that the web server can write into it.'
+            is_writable(__DIR__.'/cache'),
+            "$baseDir/cache/ directory must be writable",
+            "Change the permissions of the \"<strong>$baseDir/cache/</strong>\" directory so that the web server can write into it."
         );
 
         $this->addRequirement(
-            is_writable(__DIR__.'/../app/logs'),
-            'app/logs/ directory must be writable',
-            'Change the permissions of the "<strong>app/logs/</strong>" directory so that the web server can write into it.'
+            is_writable(__DIR__.'/logs'),
+            "$baseDir/logs/ directory must be writable",
+            "Change the permissions of the \"<strong>$baseDir/logs/</strong>\" directory so that the web server can write into it."
         );
 
         $this->addPhpIniRequirement(


### PR DESCRIPTION
Sometimes one need to have an application directory which name should not be "app". For example, there is already an "app" directory and an "api" or an "admin" directory is needed to store a wholly different, yet related,  application.

Requirements checking has "app/cache" and "app/logs" hard coded so it fails if the application directory is not "app".

I changed this to be dynamically retrieved so any application directory name will work now on.
