### PR TITLE
Updated Twig version requirements

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -100,8 +100,8 @@
         {
             "package": "twig/twig",
             "version": "dev-master",
-            "source-reference": "037f86aa550737abf633e991f3606b9de5a69657",
-            "alias": "1.7.9999999.9999999-dev"
+            "source-reference": "078905ed9507808b260d34fd8928e79e3a600d1d",
+            "alias": "1.9.9999999.9999999-dev"
         }
     ],
     "packages-dev": null,


### PR DESCRIPTION
Since Twig 1.8.0 is out the current composer.lock file leads to a dependencies error :

```
jmf@mercure:symfony-symfony-standard-1033fe9$ php composer.phar install
Installing dependencies from lock file
Your lock file is out of sync with your composer.json, run "composer.phar update" to update dependencies
Your requirements could not be solved to an installable set of packages.

    Problems:
        - Problem caused by:
            - Package "symfony/symfony-2.1.9999999.9999999-dev (alias of 9999999-dev)" contains the rule symfony/symfony requires twig/twig ([>= 1.8.0.0, < 2.0.0.0-dev]). Any of these packages satisfy the dependency: twig/twig-1.9.9999999.9999999-dev (alias of 9999999-dev), twig/twig-1.8.0.0.
            - -twig/twig-1.7.9999999.9999999-dev (alias of 9999999-dev)|-twig/twig-1.9.9999999.9999999-dev (alias of 9999999-dev)
            - -twig/twig-1.7.9999999.9999999-dev (alias of 9999999-dev)|-twig/twig-1.8.0.0
            - Install command rule (+twig/twig-1.7.9999999.9999999-dev (alias of 9999999-dev))
            - Installation of package "twig/twig" with constraint == 1.7.9999999.9999999-dev was requested. Satisfiable by packages [twig/twig-1.7.9999999.9999999-dev (alias of 9999999-dev)].
            - Install command rule (+symfony/symfony-2.1.9999999.9999999-dev (alias of 9999999-dev))
            - Installation of package "symfony/symfony" with constraint == 2.1.9999999.9999999-dev was requested. Satisfiable by packages [symfony/symfony-2.1.9999999.9999999-dev (alias of 9999999-dev)].
```

This PR updates Twig requirement to fix this issue.

By the way, Composer still complains that composer.lock is out of sync with composer.json so maybe it should be wholly updated.
