### PR TITLE
Ignored cache file build by build_bootstrap.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 web/bundles/
 app/bootstrap.php.cache
+app/bootstrap_cache.php.cache
 app/cache/*
 app/logs/*
 build/


### PR DESCRIPTION
Hi,

Since app/bootstrap_cache.php.cache is always generated on every composer install/update shouldn't it be ignored on git?

Best regards,
Luís Sousa
