### PR TITLE
Contributors: removed 2 links

### DIFF
--- a/src/Acme/DemoBundle/Resources/views/Welcome/index.html.twig
+++ b/src/Acme/DemoBundle/Resources/views/Welcome/index.html.twig
@@ -44,7 +44,6 @@
         <div class="block-documentation-more">
             <ul>
                 <li>&nbsp;</li>
-                <li><a href="http://symfony.com/doc/current/contributing/index.html">Contributing</a></li>
                 <li><a href="http://trainings.sensiolabs.com">Trainings</a></li>
                 <li><a href="http://books.sensiolabs.com">Books</a></li>
             </ul>
@@ -55,7 +54,6 @@
                 <li><a href="http://symfony.com/irc">IRC channel</a>
                 <li><a href="http://symfony.com/mailing-lists">Mailing lists</a></li>
                 <li><a href="http://forum.symfony-project.org">Forum</a></li>
-                <li><a href="http://symfony.com/doc/current/contributing/index.html">How to be involved</a></li>
                 <li><a href="http://symfony.com/doc/current/contributing/index.html">Contributing</a></li>
             </ul>
         </div>


### PR DESCRIPTION
There are three identical links on Welcome page:

```
<li><a href="http://symfony.com/doc/current/contributing/index.html">Contributing</a></li>
```

Two of them are removed in this commit.
