### PR TITLE
autoload: symbolic link to vendor/

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -9,6 +9,10 @@ if (!$loader = include __DIR__.'/../vendor/autoload.php') {
         'php composer.phar install'.$nl);
 }
 
+if (is_link(dirname(__DIR__) . '/vendor')) {
+    $loader->add('', dirname(__DIR__) . '/src/');
+}
+
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
 // intl


### PR DESCRIPTION
If we want to use the same `vendor/` folder for multiple projects we can create symbolic link named `vendor/` and pointing to a shared folder.

In this case namespaces from `src/` folder will not be found.

Attached code solves the problem.
