### PR TITLE
Added a commented out example of how to get $request to trust X_FORWARDE...

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -14,6 +14,7 @@ framework:
     validation:      { enable_annotations: true }
     templating:      { engines: ['twig'] } #assets_version: SomeVersionScheme
     default_locale:  %locale%
+    trust_proxy_headers: false # Should Request object should trust proxy headers (X_FORWARDED_FOR/HTTP_CLIENT_IP)
     session:         ~
 
 # Twig Configuration


### PR DESCRIPTION
Added a commented out example of how to get $request to trust X_FORWARDED_FOR headers in getClientIp()

When deploying a site to cloud hosting behind a reverse proxy (or similar situations) it is required to update this flag in the config file.  It is really not obvious on how to do so, as it is not mentioned in the Request class documentation (https://github.com/symfony/HttpFoundation/blob/master/Request.php#L447)

Having it in there at least makes it easier to find out how to switch across to trusting proxies when your site is all of a sudden behind a reverse proxy.  It took me a good 30mins to an hour the first time to figure this out after digging around in the code.
