### PR TITLE
Fixed indenting of code example in UPGRADE.md

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -38,22 +38,22 @@ The default `autoload.php` reads as follows (it has been simplified a lot as
 autoloading for libraries and bundles declared in your `composer.json` file is
 automatically managed by the Composer autoloader):
 
-  <?php
+    <?php
 
-  use Doctrine\Common\Annotations\AnnotationRegistry;
+    use Doctrine\Common\Annotations\AnnotationRegistry;
 
-  $loader = include __DIR__.'/../vendor/autoload.php';
+    $loader = include __DIR__.'/../vendor/autoload.php';
 
-  // intl
-  if (!function_exists('intl_get_error_code')) {
-      require_once __DIR__.'/../vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs/functions.php';
+    // intl
+    if (!function_exists('intl_get_error_code')) {
+        require_once __DIR__.'/../vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs/functions.php';
 
-      $loader->add('', __DIR__.'/../vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs');
-  }
+        $loader->add('', __DIR__.'/../vendor/symfony/symfony/src/Symfony/Component/Locale/Resources/stubs');
+    }
 
-  AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
+    AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
 
-  return $loader;
+    return $loader;
 
 ### `app/config/config.yml`
 


### PR DESCRIPTION
Indenting of first code example needed to be increased to make github render it as code.
