### PR TITLE
Rename framework.router.strict_parameters to strict_requirements

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -71,13 +71,13 @@ class instead:
         // ...
     }
 
-You might want to add the new `strict_parameters` parameter to
+You might want to add the new `strict_requirements` parameter to
 `framework.router` (it avoids fatal errors in the production environment when
 a link cannot be generated):
 
     framework:
         router:
-            strict_parameters: %kernel.debug%
+            strict_requirements: %kernel.debug%
 
 The `default_locale` parameter is now a setting of the main `framework`
 configuration (it was under the `framework.session` in 2.0):


### PR DESCRIPTION
Doc update - to match https://github.com/symfony/symfony/commit/4b521985f121be25360365e2dc7a36645daa26b1

and

https://github.com/symfony/symfony-standard/commit/6e3f568d0ace2fe674feb6e8b64e7b43aff7a0ca
