### PR TITLE
Adding bin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ app/cache/*
 app/logs/*
 build/
 vendor
+bin
 composer.phar


### PR DESCRIPTION
Composer moves or links bin files to the bin directory, so 
checking these files in after installing deps with composer 
doesn't make any sense.
