### PR TITLE
[Acme] Highlight code block in demo pages

### DIFF
--- a/src/Acme/DemoBundle/Twig/Extension/DemoExtension.php
+++ b/src/Acme/DemoBundle/Twig/Extension/DemoExtension.php
@@ -33,7 +33,10 @@ class DemoExtension extends \Twig_Extension
 
     public function getCode($template)
     {
-        $controller = htmlspecialchars($this->getControllerCode(), ENT_QUOTES, 'UTF-8');
+        // highlight_string highlights php code only if '<?php' tag is present.
+        $controller = highlight_string("<?php" . $this->getControllerCode(), true);
+        $controller = str_replace('<span style="color: #0000BB">&lt;?php&nbsp;&nbsp;&nbsp;&nbsp;</span>', '&nbsp;&nbsp;&nbsp;&nbsp;', $controller);
+
         $template = htmlspecialchars($this->getTemplateCode($template), ENT_QUOTES, 'UTF-8');
 
         // remove the code block


### PR DESCRIPTION
This feature is not very important, but it's fun :tropical_drink:.

P.S. : `htmlspecialchars` is not needed anymore, `highlight_string` already escape (I guess)
