### PR TITLE
Disable the load of class cache when the XDebug session is detected

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -23,7 +23,8 @@ $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
 require_once __DIR__.'/../app/AppKernel.php';
 
 $kernel = new AppKernel('dev', true);
-if (!isset($_REQUEST['XDEBUG_SESSION_START']) && !isset($_COOKIE['XDEBUG_SESSION'])) {
+//This check tries to detect a XDebug session to prevent the load of class cache
+if (!extension_loaded('xdebug') || (!isset($_REQUEST['XDEBUG_SESSION_START']) && !isset($_COOKIE['XDEBUG_SESSION']) && ini_get('xdebug.remote_autostart') == false)) {
     $kernel->loadClassCache();
 }
 $request = Request::createFromGlobals();


### PR DESCRIPTION
After reading the recipe to [optimize the development Environment for debugging](http://symfony.com/doc/current/cookbook/debugging.html#cookbook-debugging-disable-bootstrap) I've thought that it will be nice to implement a feature to detect when an XDebug session is running and prevent the load of class cache automatically. This way, I will never forget to enable it again.

See http://xdebug.org/docs/remote#browser_session
