### PR TITLE
Added a bit more info about the unreleased PHP 5.3.17 requirement when using PHP 5.3.16

### DIFF
--- a/app/SymfonyRequirements.php
+++ b/app/SymfonyRequirements.php
@@ -507,8 +507,8 @@ class SymfonyRequirements extends RequirementCollection
 
         $this->addRequirement(
             version_compare($installedPhpVersion, '5.3.16', '!='),
-            'Symfony won\'t work properly with PHP 5.3.16 due to issues in this version',
-            'Install PHP 5.3.17 or newer when possible, or downgrade to PHP 5.3.15'
+            'Symfony won\'t work properly with PHP 5.3.16 due to PHP bug #62874',
+            'Install PHP 5.3.17 or newer when possible, or downgrade to PHP 5.3.15.'
         );
 
         /* optional recommendations follow */


### PR DESCRIPTION
There was some confusion about the PHP 5.3.16 warning because 5.3.17 is not yet released.
Added a bit more info to clear things up.
