### PR TITLE
composer.json without minimum-stability

### DIFF
--- a/app/Resources/stable-release/README.md
+++ b/app/Resources/stable-release/README.md
@@ -1,0 +1,38 @@
+Using stable releases
+=====================
+
+Symfony Standard Edition is delivered by default with a composer.json
+file that will fetch the latest dev release of Symfony2 and the
+suggested bundles for this edition.
+
+
+## Locking in stable release
+
+Should you want to lock in as much stable releases of Symfony2 and the
+bundles defined in this edition, replace your composer.json with the
+content of the composer.json file within this folder.
+
+
+## Adding a bundle that does not have a stable release yet
+
+Some bundles you will want to add might not have a stable release available
+yet and may instruct you to add a composer entry that uses a "x.x.*" version
+number without explicitly pointing to their "dev" release. If composer cannot
+resolve its dependencies for that bundle, try appending `@dev` to its version
+value.
+
+
+Example:
+
+    "require" {
+        ...
+        "kriswallsmith/assetic": "1.1.*"
+    }
+
+
+Would become:
+
+    "require" {
+        ...
+        "kriswallsmith/assetic": "1.1.*@dev"
+    }

--- a/app/Resources/stable-release/composer.json
+++ b/app/Resources/stable-release/composer.json
@@ -1,0 +1,44 @@
+{
+    "name": "symfony/framework-standard-edition",
+    "description": "The \"Symfony Standard Edition\" distribution",
+    "autoload": {
+        "psr-0": { "": "src/" }
+    },
+    "require": {
+        "php": ">=5.3.3",
+        "symfony/symfony": "2.1.*",
+        "doctrine/orm": ">=2.2.3,<2.4-dev",
+        "doctrine/doctrine-bundle": "1.0.*",
+        "twig/extensions": "1.0.*@dev",
+        "symfony/assetic-bundle": "2.1.*",
+        "kriswallsmith/assetic": "1.1.*@dev",
+        "symfony/swiftmailer-bundle": "2.1.*",
+        "symfony/monolog-bundle": "2.1.*",
+        "sensio/distribution-bundle": "2.1.*",
+        "sensio/framework-extra-bundle": "2.1.*",
+        "sensio/generator-bundle": "2.1.*",
+        "jms/security-extra-bundle": "1.2.*",
+        "jms/di-extra-bundle": "1.1.*"
+    },
+    "scripts": {
+        "post-install-cmd": [
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
+        ],
+        "post-update-cmd": [
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile"
+        ]
+    },
+    "config": {
+        "bin-dir": "bin"
+    },
+    "extra": {
+        "symfony-app-dir": "app",
+        "symfony-web-dir": "web"
+    }
+}


### PR DESCRIPTION
Following failed attempts and a very useful conversation on https://github.com/symfony/symfony-standard/issues/402, I created a composer.json and README.me file in app/Resources/stable-relase for those who would want to lock in stable releases as much as possible.
