### PR TITLE
Note about sqlite needing path param

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -45,6 +45,9 @@ doctrine:
         user:     %database_user%
         password: %database_password%
         charset:  UTF8
+        # if using pdo_sqlite as your database driver, add the path in parameters.yml
+        # e.g. database_path: %kernel.root_dir%/data/data.db3
+        # path:     %database_path%
 
     orm:
         auto_generate_proxy_classes: %kernel.debug%


### PR DESCRIPTION
Adding note about sqlite databases needing a path parameter to config.yml
