### PR TITLE
Add fe80::1 to list of loopback addresses.

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -12,6 +12,7 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
     || !in_array(@$_SERVER['REMOTE_ADDR'], array(
         '127.0.0.1',
+        'fe80::1',
         '::1',
     ))
 ) {


### PR DESCRIPTION
On my Mac, the loopback interface is configured (via `/etc/hosts`, out of the box) to have both a link-local and a node-local loopback address, with the link-local address taking precedence:

```
lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
    options=3<RXCSUM,TXCSUM>
    inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1 
    inet 127.0.0.1 netmask 0xff000000 
    inet6 ::1 prefixlen 128 
```

That obviously results in a `REMOTE_ADDR` of "fe80::1" rather than just "::1".
