### PR TITLE
Update composer.lock to a new DoctrinBundle commit

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -139,7 +139,7 @@
             "source": {
                 "type": "git",
                 "url": "git://github.com/doctrine/DoctrineBundle.git",
-                "reference": "4fa47caf19c426d607a636b2da73bc0e5a87ec66"
+                "reference": "47df202dfb4ad38e15d6aed8a53e722b30c9f9fd"
             },
             "dist": {
                 "type": "zip",


### PR DESCRIPTION
This is related to this:
https://github.com/symfony/symfony-standard/issues/444#
and to this:
https://github.com/doctrine/DoctrineBundle/pull/136
Updating the reference should fix everything.
