### PR TITLE
Add note to the 2.1 upgrade doc

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,6 +32,8 @@ Finally, run Composer:
 
     $ composer.phar install
 
+Note: You must complete the upgrade steps below so composer can successfully generate the autoload files.
+
 ### `app/autoload.php`
 
 The default `autoload.php` reads as follows (it has been simplified a lot as


### PR DESCRIPTION
When upgrading from 2.0 -> 2.1, composer.phar will fail with a runtime exception when attempting to generate the autoload bootstrap file if the install is attempted before updating the existing files as per the guide (config.yml, app.php etc).
