### PR TITLE
Use route names for login/check/logout paths in security.yml

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -29,11 +29,11 @@ security:
         secured_area:
             pattern:    ^/demo/secured/
             form_login:
-                check_path: /demo/secured/login_check
-                login_path: /demo/secured/login
+                check_path: _security_check
+                login_path: _demo_login
             logout:
-                path:   /demo/secured/logout
-                target: /demo/
+                path:   _demo_logout
+                target: _demo
             #anonymous: ~
             #http_basic:
             #    realm: "Secured Demo Area"


### PR DESCRIPTION
It might be a good idea to switch the firewall login, logout and check paths to route names in `security.yml`, if only to draw attention to the fact that it’s possible (and probably a good idea?):

```
secured_area:
    pattern:    ^/demo/secured/
    form_login:
        check_path: _security_check
        login_path: _demo_login
    logout:
        path:   _demo_logout
        target: _demo
```

As mentioned in symfony/symfony#1493, it’s apparently the right way to do it if you want a localised login page. At least that’s what I had to do after I prefixed the FOSUserBundle routes with `/{_locale}/`.
