### PR TITLE
Check if HTTP_X_FORWARDED_FOR is localhost

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -8,9 +8,10 @@ use Symfony\Component\HttpFoundation\Request;
 
 // This check prevents access to debug front controllers that are deployed by accident to production servers.
 // Feel free to remove this, extend it, or make something more sophisticated.
+$localhost = array('127.0.0.1', 'fe80::1', '::1');
 if (isset($_SERVER['HTTP_CLIENT_IP'])
-    || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1'))
+    || (isset($_SERVER['HTTP_X_FORWARDED_FOR']) && !in_array(@$_SERVER['HTTP_X_FORWARDED_FOR'], $localhost))
+    || !in_array(@$_SERVER['REMOTE_ADDR'], $localhost)
 ) {
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');


### PR DESCRIPTION
On my dev environment I'm using varnish to test http_cache and another things and the varnish are using the header HTTP_X_FORWARDED_FOR, so the app_dev.php deny the access.

With this patch will be possible use varnish/pound with app_dev.php
