### PR TITLE
switched to autoload.php in the dev front controller

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -17,7 +17,7 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
-require_once __DIR__.'/../app/bootstrap.php.cache';
+require_once __DIR__.'/../app/autoload.php';
 require_once __DIR__.'/../app/AppKernel.php';
 
 use Symfony\Component\HttpFoundation\Request;


### PR DESCRIPTION
This can be misleading me when debugging things, I was wondering why my breakpoint was never reached until I figured out the class in question was dumped in the bootstrap.
