### PR TITLE
Update monolog-bundle dependency to 2.2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "twig/extensions": "1.0.*",
         "symfony/assetic-bundle": "2.1.*",
         "symfony/swiftmailer-bundle": "2.2.*",
-        "symfony/monolog-bundle": "2.1.*",
+        "symfony/monolog-bundle": "2.2.*",
         "sensio/distribution-bundle": "2.2.*",
         "sensio/framework-extra-bundle": "2.2.*",
         "sensio/generator-bundle": "2.2.*",


### PR DESCRIPTION
Dependency on the old monolog bundle is causing a <1.3 version of
monolog to be installed, which is causing breakage because that
version does not implement the PSR-3 interface yet. 
