### PR TITLE
Updated DoctrineBundle to 1.1.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": ">=5.3.3",
         "symfony/symfony": "2.1.*",
         "doctrine/orm": ">=2.2.3,<2.4-dev",
-        "doctrine/doctrine-bundle": "1.0.*",
+        "doctrine/doctrine-bundle": "1.1.*",
         "twig/extensions": "1.0.*@dev",
         "symfony/assetic-bundle": "2.1.*",
         "symfony/swiftmailer-bundle": "2.1.*",


### PR DESCRIPTION
The branch alias of DoctrineBundle master was previously 1.0.x-dev, but it was adding new features. So it has been released as 1.1.0 instead. This will allow people starting with the next Symfony 2.1 release to benefit from the DoctrineBundle improvements done in the last 6 months.

Another PR for 2.2 is coming
