### PR TITLE
checked if the path doesn't match a directory too

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -5,6 +5,7 @@
     #    RewriteBase /
     #</IfModule>
 
+    RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^(.*)$ app.php [QSA,L]
 </IfModule>


### PR DESCRIPTION
So that it gets handled by the webserver.

My use case is a folder with static files (html js and css), I was expecting that for `/folder` path the `index.html` file in it were served (because of apache's DirectoryIndex) but I had a Symfony error instead.
