### PR TITLE
Enabled the router proxy by default

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -16,7 +16,7 @@ framework:
     default_locale:  "%locale%"
     trusted_proxies: ~
     session:         ~
-    #router_proxy:   { path: /_proxy }
+    router_proxy:   { path: /_proxy }
 
 # Twig Configuration
 twig:


### PR DESCRIPTION
DoctrineBundle uses the controller notation in its profiler
