### PR TITLE
Narrow paths being ignored by git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-web/bundles/
-app/bootstrap.php.cache
-app/cache/*
-app/logs/*
-build/
-vendor
-bin
-composer.phar
+/web/bundles/
+/app/bootstrap.php.cache
+/app/cache/*
+/app/logs/*
+/build/
+/vendor/
+/bin/
+/composer.phar


### PR DESCRIPTION
With current patterns paths like `web/vendor/bootstrap-2.2.2` are ignored.
