### PR TITLE
redirect /app.php to prevent duplicate content

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -1,36 +1,48 @@
+# Use the front controller as index file. It serves as fallback solution when
+# every other rewrite/redirect fails (e.g. in an aliased environment without
+# mod_rewrite). Additionally, this reduces the matching process for the
+# startpage (path "/") because otherwise Apache will apply the rewritting rules
+# to each configured DirectoryIndex file (e.g. index.php, index.html, index.pl).
+DirectoryIndex app.php
+
 <IfModule mod_rewrite.c>
     RewriteEngine On
 
-    # This reduces the matching process for the startpage (path "/") because
-    # otherwise apache will apply the rewritting rules to each configured
-    # DirectoryIndex file needlessly (e.g. index.php, index.html, index.pl).
-    DirectoryIndex
-
     # Redirect to URI without front controller to prevent duplicate content
     # (with and without `/app.php`). Only do this redirect on the initial
-    # rewrite by apache and not on subsequent cycles. Otherwise we would get an
+    # rewrite by Apache and not on subsequent cycles. Otherwise we would get an
     # endless redirect loop (request -> rewrite to front controller ->
     # redirect -> request -> ...).
-    # So in case you get a "too many redirects" error because your apache does
-    # not expose the REDIRECT_STATUS environment variable, you have 2 choices:
+    # So in case you get a "too many redirects" error or you always get redirected
+    # to the startpage because your Apache does not expose the REDIRECT_STATUS
+    # environment variable, you have 2 choices:
     # - disable this feature by commenting the following 2 lines or
-    # - use apache >= 2.3.9 and replace all L flags by END flags and remove the
+    # - use Apache >= 2.3.9 and replace all L flags by END flags and remove the
     #   following RewriteCond (best solution)
     RewriteCond %{ENV:REDIRECT_STATUS} ^$
     RewriteRule ^app\.php(/(.*)|$) %{CONTEXT_PREFIX}/$2 [R=301,L]
 
     # If the requested filename exists, simply serve it.
-    # We only want to let apache serve files and not directories.
+    # We only want to let Apache serve files and not directories.
     RewriteCond %{REQUEST_FILENAME} -f
     RewriteRule .? - [L]
 
-    # The following rewrites all other queries to app.php. The
-    # condition ensures that if you are using Apache aliases to do
-    # mass virtual hosting, the base path will be prepended to
-    # allow proper resolution of the app.php file; it will work
-    # in non-aliased environments as well, providing a safe, one-size
-    # fits all solution.
+    # The following rewrites all other queries to the front controller. The
+    # condition ensures that if you are using Apache aliases to do mass virtual
+    # hosting, the base path will be prepended to allow proper resolution of the
+    # app.php file; it will work in non-aliased environments as well, providing
+    # a safe, one-size fits all solution.
     RewriteCond %{REQUEST_URI}::$1 ^(/.+)(.+)::\2$
     RewriteRule ^(.*) - [E=BASE:%1]
     RewriteRule .? %{ENV:BASE}app.php [L]
+</IfModule>
+
+<IfModule !mod_rewrite.c>
+    <IfModule mod_alias.c>
+        # When mod_rewrite is not available, we instruct a temporary redirect of
+        # the startpage to the front controller explicitly so that the website
+        # and the generated links can still be used.
+        RedirectMatch 302 ^/$ /app.php/
+        # RedirectTemp cannot be used instead
+    </IfModule>
 </IfModule>


### PR DESCRIPTION
Improved version of #497. This time it's compatible with Apache < 2.3.9 by not using the END flag. It also features default compatibility with apache aliases (inspired by [Zend](https://github.com/zendframework/ZendSkeletonApplication/blob/master/public/.htaccess)). And it improves the rewriting performance for the homepage by preventing the process to apply to each DirectoryIndex file.

Now I could also make the startpage work when mod_rewrite is not available.

I tested it thoroughly and also debugged apache rewriting to see what's happening.
It was quite hard to find out how to achieve all that. [This resource](http://stackoverflow.com/questions/7798099/how-to-block-multiple-mod-rewrite-passes-or-infinite-loops-in-a-htaccess-cont) helped quite a bit.

May be good if someone else can confirm all works.

Example behavior for each scenario:

With mod_rewrite:
- `/` -> internally rewritten to use front controller (`app.php`)
- `/path` -> internally rewritten to use front controller
- `/app.php/path` -> external permanent redirect to `/path` to prevent duplicate content
- `/app.php` or `/app.php/`-> external permanent redirect to `/` to prevent duplicate content
- `/app.phpF` stays as-is

Without mod_rewrite but with mod_alias (default module):
- `/` -> external temporary redirect to `/app.php/` so it's explicit and all generated links on the startpage also work with the base path prepended
- `/path` -> stays as-is and would probably return a 404 (we cannot safely and easily redirect with mod_alias to `/app.php/path` because we don't know if the request references a real file like CSS)
- `/app.php/path` -> stays as-is and works because the front controller is given
- `/app.php` -> stays as-is and works because the front controller is given

In an aliased environment with mod_rewrite:
- `/myproject/` -> internally rewritten to use front controller (`app.php`)
- `/myproject/path` -> internally rewritten to use front controller
- `/myproject/app.php/path` -> external permanent redirect to `/myproject/path` to prevent duplicate content
- `/myproject/app.php` -> external permanent redirect to `/myproject/` to prevent duplicate content

In an aliased environment without mod_rewrite:
- `/myproject/` -> stays as-is and works because it uses the DirectoryIndex definition (but the links will not work)
- `/myproject/path` -> stays as-is and would probably return a 404 (except there is such a file)
- `/myproject/app.php/path` -> stays as-is and works because the front controller is given
- `/myproject/app.php` -> stays as-is and works because the front controller is given
