### PR TITLE
Remove a deprecated call to bindRequest()

### DIFF
--- a/src/Acme/DemoBundle/Controller/DemoController.php
+++ b/src/Acme/DemoBundle/Controller/DemoController.php
@@ -40,7 +40,7 @@ class DemoController extends Controller
 
         $request = $this->get('request');
         if ('POST' == $request->getMethod()) {
-            $form->bindRequest($request);
+            $form->bind($request);
             if ($form->isValid()) {
                 $mailer = $this->get('mailer');
                 // .. setup a message and send it


### PR DESCRIPTION
Quick fix to replace `bindRequest()` to  `bind()` in the `DemoController.php` exemple.
