### PR TITLE
Added $loader variable typehint for easier manipulation in IDEs.

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -1,7 +1,11 @@
 <?php
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
+use Composer\Autoload\ClassLoader;
 
+/**
+ * @var $loader ClassLoader
+ */
 $loader = require __DIR__.'/../vendor/autoload.php';
 
 // intl


### PR DESCRIPTION
Not all project dependencies are managed by Composer. Common solutions for (company / private) libraries and bundles are git submodules or even symlinked directories.

This PR adds typehint for `$loader` variable inside `app/autoload.php` so people won't need to search for information on what class it is and what interface it exposes when trying to add their code to autoloader.
