### PR TITLE
Add commented framework.validation.cache = apc to prod config

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -8,6 +8,8 @@ imports:
 framework:
     router:
         strict_requirements: null
+    #validation:
+    #    cache: apc
 
 #doctrine:
 #    orm:


### PR DESCRIPTION
Hey,

After some XHProf, I found that this setting was important to get the best performance in production.

I think it make sense to have it as a comment like doctrine caches.
