### PR TITLE
Remove deprecated call to Session::setFlash

### DIFF
--- a/src/Acme/DemoBundle/Controller/DemoController.php
+++ b/src/Acme/DemoBundle/Controller/DemoController.php
@@ -46,7 +46,7 @@ class DemoController extends Controller
                 // .. setup a message and send it
                 // http://symfony.com/doc/current/cookbook/email.html
 
-                $this->get('session')->setFlash('notice', 'Message sent!');
+                $this->get('session')->getFlashBag()->set('notice', 'Message sent!');
 
                 return new RedirectResponse($this->generateUrl('_demo'));
             }


### PR DESCRIPTION
Using getFlashBag method instead.
