### PR TITLE
fix redirect when project is installed in subdirectory

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -8,6 +8,16 @@ DirectoryIndex app.php
 <IfModule mod_rewrite.c>
     RewriteEngine On
 
+    # Determine the RewriteBase automatically and set it as environment variable.
+    # If you are using Apache aliases to do mass virtual hosting or installed the
+    # project in a subdirectory, the base path will be prepended to allow proper
+    # resolution of the app.php file and to redirect to the correct URI. It will
+    # work in environments without path prefix as well, providing a safe, one-size
+    # fits all solution. But as you do not need it in this case, you can comment
+    # the following 2 lines to eliminate the overhead.
+    RewriteCond %{REQUEST_URI}::$1 ^(/.+)/(.+)::\2$
+    RewriteRule ^(.*) - [E=BASE:%1]
+
     # Redirect to URI without front controller to prevent duplicate content
     # (with and without `/app.php`). Only do this redirect on the initial
     # rewrite by Apache and not on subsequent cycles. Otherwise we would get an
@@ -20,21 +30,15 @@ DirectoryIndex app.php
     # - use Apache >= 2.3.9 and replace all L flags by END flags and remove the
     #   following RewriteCond (best solution)
     RewriteCond %{ENV:REDIRECT_STATUS} ^$
-    RewriteRule ^app\.php(/(.*)|$) %{CONTEXT_PREFIX}/$2 [R=301,L]
+    RewriteRule ^app\.php(/(.*)|$) %{ENV:BASE}/$2 [R=301,L]
 
     # If the requested filename exists, simply serve it.
     # We only want to let Apache serve files and not directories.
     RewriteCond %{REQUEST_FILENAME} -f
     RewriteRule .? - [L]
 
-    # The following rewrites all other queries to the front controller. The
-    # condition ensures that if you are using Apache aliases to do mass virtual
-    # hosting, the base path will be prepended to allow proper resolution of the
-    # app.php file; it will work in non-aliased environments as well, providing
-    # a safe, one-size fits all solution.
-    RewriteCond %{REQUEST_URI}::$1 ^(/.+)(.+)::\2$
-    RewriteRule ^(.*) - [E=BASE:%1]
-    RewriteRule .? %{ENV:BASE}app.php [L]
+    # Rewrite all other queries to the front controller.
+    RewriteRule .? %{ENV:BASE}/app.php [L]
 </IfModule>
 
 <IfModule !mod_rewrite.c>


### PR DESCRIPTION
When neither a vhost with proper document root nor an apache alias is configured, the redirect was to the wrong location (without the path prefix). The context_prefix env variable was not available then, so we need to use the logic to determine the RewriteBase automatically as we have done it to resolve the app.php file too.

BC break: no
fixes: https://github.com/symfony/symfony-standard/pull/497#issuecomment-16016232 and following
