### PR TITLE
Vagrant Configuration

### DIFF
--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,71 @@
+Symfony Standard Edition with Vagrant
+=====================================
+
+You can easily setup a development environment for the Symfony Standard Edition
+by using [Vagrant][1].
+
+Prerequisites
+-------------
+
+1. Download and install the latest [Virtualbox][2].
+2. Download and install the latest [Vagrant][3].
+3. Install the Symfony Standard Edition as detailed in the main README.md file.
+
+Setup
+-----
+
+After installing the Symfony Standard Edition, execute the following commands:
+
+    cd vagrant
+    vagrant up
+
+A virtual machine is now being prepared in Virtualbox by Vagrant. When the
+process has completed, you can view the Symfony demo site in a browser at:
+
+<http://192.168.33.10/app_dev.php>
+
+Now you can start developing with Symfony! Any changes made to your Symfony
+project directory will appear in the virtual machine.
+
+Further Configuration
+---------------------
+
+A MySQL database has been created on the Vagrant virtual machine which you can
+use. Just update your app/config/parameters.yml file:
+
+    parameters:
+        database_driver:   pdo_mysql
+        database_host:     127.0.0.1
+        database_port:     ~
+        database_name:     symfony
+        database_user:     symfony
+        database_password: symfony
+
+The database name, user, and password are "symfony".
+
+Other Vagrant Commands
+----------------------
+
+While you are in the "vagrant" directory, you can perform other commands.
+
+If you need to access the virtual machine command line, execute:
+
+    vagrant ssh
+
+If you need to refresh the virtual machine, execute:
+
+    vagrant reload
+
+If you are done developing and want to remove the virtual machine, execute:
+
+    vagrant destroy
+
+And if you want to install again after destroying, execute:
+
+    vagrant up
+
+Enjoy!
+
+[1]: http://www.vagrantup.com
+[2]: https://www.virtualbox.org/wiki/Downloads
+[3]: http://downloads.vagrantup.com/

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "precise32"
+
+  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+
+  config.vm.network :private_network, ip: "192.168.33.10"
+
+  config.vm.synced_folder "..", "/vagrant" #, :nfs => true
+
+  config.vm.provision :shell, :path => "puppet/modules.sh"
+
+  config.vm.provision :puppet do |puppet|
+    puppet.manifests_path = "puppet/manifests"
+    puppet.manifest_file  = "symfony.pp"
+    puppet.facter = {
+        "fqdn"           => "symfony.local",
+        "host_ipaddress" => "192.168.33.1",
+    }
+  end
+end

--- a/vagrant/puppet/manifests/symfony.pp
+++ b/vagrant/puppet/manifests/symfony.pp
@@ -1,0 +1,171 @@
+# update system first before new packages are installed
+class { 'apt':
+    always_apt_update => true,
+}
+Exec['apt_update'] -> Package <| |>
+
+
+# install Apache
+class { 'apache': }
+class { 'apache::mod::php': }
+
+
+# install MySQL
+class { 'mysql': }
+class { 'mysql::server':
+    config_hash => { 'root_password' => 'symfony' },
+}
+class { 'mysql::php': }
+
+
+# install Git for composer
+class { 'git': }
+
+
+# install PHP Extensions used with Symfony
+class php-extensions {
+    package { ['php-apc', 'php5-intl', 'php5-xdebug']:
+        ensure  => latest,
+        require => Package['httpd'],
+        notify  => Service['httpd'],
+    }
+}
+
+include php-extensions
+
+
+# install a local composer.phar file
+class composer {
+    exec { 'composerPhar':
+        cwd     => '/vagrant',
+        command => 'curl -s http://getcomposer.org/installer | php',
+        path    => ['/bin', '/usr/bin'],
+        creates => '/vagrant/composer.phar',
+        require => [ Class['apache::mod::php', 'git'], Package['curl'] ],
+    }
+
+    package { 'curl':
+        ensure => present,
+    }
+}
+
+include composer
+
+
+# install the Symfony vendors using composer
+class symfony {
+    exec { 'vendorsInstall':
+        cwd       => '/vagrant',
+        command   => 'php composer.phar install',
+        timeout   => 1200,
+        path      => ['/bin', '/usr/bin'],
+        creates   => '/vagrant/vendor',
+        logoutput => true,
+        require   => Exec['composerPhar'],
+    }
+}
+
+include symfony
+
+
+# Create a web server host using the Symfony web/ directory
+apache::vhost { 'www.symfony.local':
+    priority      => '10',
+    port          => '80',
+    docroot_owner => 'vagrant',
+    docroot_group => 'vagrant',
+    docroot       => '/vagrant/web/',
+    logroot       => '/vagrant/app/logs/',
+    serveraliases => ['symfony.local',],
+}
+
+# Create a database for Symfony
+mysql::db { 'symfony':
+    user     => 'symfony',
+    password => 'symfony',
+    host     => 'localhost',
+    grant    => ['all'],
+}
+
+
+# Configure Apache files to run as the "vagrant" user so that Symfony app/cache
+# and app/logs files can be successfully created and accessed by the web server
+
+file_line { 'apache_user':
+    path    => '/etc/apache2/httpd.conf',
+    line    => 'User vagrant',
+    require => Package['httpd'],
+    notify  => Service['httpd'],
+}
+
+file_line { 'apache_group':
+    path    => '/etc/apache2/httpd.conf',
+    line    => 'Group vagrant',
+    require => Package['httpd'],
+    notify  => Service['httpd'],
+}
+
+
+# Configure php.ini to follow recommended Symfony web/config.php settings
+
+file_line { 'php5_apache2_short_open_tag':
+    path    => '/etc/php5/apache2/php.ini',
+    match   => 'short_open_tag =',
+    line    => 'short_open_tag = Off',
+    require => Class['apache::mod::php'],
+    notify  => Service['httpd'],
+}
+
+file_line { 'php5_cli_short_open_tag':
+    path    => '/etc/php5/cli/php.ini',
+    match   => 'short_open_tag =',
+    line    => 'short_open_tag = Off',
+    require => Class['apache::mod::php'],
+    notify  => Service['httpd'],
+}
+
+file_line { 'php5_apache2_date_timezone':
+    path    => '/etc/php5/apache2/php.ini',
+    match   => 'date.timezone =',
+    line    => 'date.timezone = UTC',
+    require => Class['apache::mod::php'],
+    notify  => Service['httpd'],
+}
+
+file_line { 'php5_cli_date_timezone':
+    path    => '/etc/php5/cli/php.ini',
+    match   => 'date.timezone =',
+    line    => 'date.timezone = UTC',
+    require => Class['apache::mod::php'],
+    notify  => Service['httpd'],
+}
+
+file_line { 'php5_apache2_xdebug_max_nesting_level':
+    path    => '/etc/php5/apache2/conf.d/xdebug.ini',
+    line    => 'xdebug.max_nesting_level = 250',
+    require => [ Class['apache::mod::php'], Package['php5-xdebug'] ],
+    notify  => Service['httpd'],
+}
+
+file_line { 'php5_cli_xdebug_max_nesting_level':
+    path    => '/etc/php5/cli/conf.d/xdebug.ini',
+    line    => 'xdebug.max_nesting_level = 250',
+    require => [ Class['apache::mod::php'], Package['php5-xdebug'] ],
+    notify  => Service['httpd'],
+}
+
+
+# Configure Symfony dev controllers so that the Vagrant host machine at the
+# host_ipaddress (specified in the Vagrantfile) has access
+
+file_line { 'symfony_web_config_host_ipaddress':
+    path  => '/vagrant/web/config.php',
+    match => '::1',
+    line  => "    '::1', '${::host_ipaddress}',",
+}
+
+file_line { 'symfony_web_app_dev_host_ipaddress':
+    path  => '/vagrant/web/app_dev.php',
+    match => '::1',
+    line  => "    || !in_array(@\$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1', '${::host_ipaddress}'))",
+}

--- a/vagrant/puppet/modules.sh
+++ b/vagrant/puppet/modules.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+if [ ! -d "/etc/puppet/modules" ]; then
+    mkdir -p /etc/puppet/modules;
+fi
+
+if [ ! -d "/etc/puppet/modules/apache" ]; then
+    puppet module install puppetlabs-apache;
+fi
+
+if [ ! -d "/etc/puppet/modules/mysql" ]; then
+    puppet module install puppetlabs-mysql;
+fi
+
+if [ ! -d "/etc/puppet/modules/apt" ]; then
+    puppet module install puppetlabs-apt;
+fi
+
+if [ ! -d "/etc/puppet/modules/git" ]; then
+    puppet module install puppetlabs-git;
+fi


### PR DESCRIPTION
Added Vagrant configuration files based on the discussion from #407.

This configuration uses the Ubuntu precise32 base box used throughout the Vagrant documentation (such as http://docs.vagrantup.com/v2/getting-started/index.html).  It also uses Puppet modules retrieved by a script from the http://forge.puppetlabs.com/puppetlabs list.
