### PR TITLE
Disable CSRF protection in test mode

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -2,11 +2,10 @@ imports:
     - { resource: config_dev.yml }
 
 framework:
-    test: ~
-    session:
-        storage_id: session.storage.mock_file
-    profiler:
-        enabled: false
+    test:            ~
+    session:         { storage_id: session.storage.mock_file }
+    profiler:        { enabled: false }
+    csrf_protection: { enabled: false }
 
 web_profiler:
     toolbar: false


### PR DESCRIPTION
By disabling this protection, we can now test dynamic forms (involving javascript to generate needed fields) by submitting directly the known values to action URI.

_Not possible if fields are generated by JS_ 

```
$client->submit($form, array(
    'form[tags][0]['value'] => 'foo',
    'form[tags][1]['value'] => 'bar',
));
```

_Not possible if CSRF is enabled_

```
$client->request('POST', '/uri/to/action', array(
    'form' => array(
        'tags' => array(
            array('value' => 'foo'),
            array('value' => 'bar'),
        ),
    ),
);
```
