### PR TITLE
Fix deprecated function

### DIFF
--- a/src/Acme/DemoBundle/Controller/DemoController.php
+++ b/src/Acme/DemoBundle/Controller/DemoController.php
@@ -40,7 +40,7 @@ class DemoController extends Controller
 
         $request = $this->get('request');
         if ($request->isMethod('POST')) {
-            $form->bind($request);
+            $form->submit($request);
             if ($form->isValid()) {
                 $mailer = $this->get('mailer');
                 // .. setup a message and send it


### PR DESCRIPTION
In AcmeDemoController/contactAction there was the deprecated function $form->bind() instead of $form->submit()
