### PR TITLE
Added 2.3 upgrade notes

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -1,0 +1,5 @@
+UPGRADE FROM 2.2 to 2.3
+=======================
+
+ * You now have to manually enable the [debug component](http://symfony.com/blog/new-in-symfony-2-3-new-debug-component) in [`web/app_dev.php`](https://github.com/symfony/symfony-standard/blob/2.3/web/app_dev.php)
+   by adding `Debug::enable();` just after including the boostrap cache.


### PR DESCRIPTION
After upgrading to symfony-2.3 I noticed that the debugging was crippled. I could not find anything in the upgrade notes, so here it is. I am not sure if I phrased it correctly.

PS Yes, I know, I should've subscribed symfony blog ages ago. I did so now.
