### PR TITLE
Detect Zend OPcache and WinCache as PHP Accelerators

### DIFF
--- a/app/SymfonyRequirements.php
+++ b/app/SymfonyRequirements.php
@@ -622,11 +622,15 @@ class SymfonyRequirements extends RequirementCollection
         }
 
         $accelerator =
-            (function_exists('apc_store') && ini_get('apc.enabled'))
+            (extension_loaded('eaccelerator') && ini_get('eaccelerator.enable'))
             ||
-            function_exists('eaccelerator_put') && ini_get('eaccelerator.enable')
+            (extension_loaded('apc') && ini_get('apc.enabled'))
             ||
-            function_exists('xcache_set')
+            (extension_loaded('Zend OPcache') && ini_get('opcache.enable'))
+            ||
+            (extension_loaded('xcache') && ini_get('xcache.cacher'))
+            ||
+            (extension_loaded('wincache') && ini_get('wincache.ocenabled'))
         ;
 
         $this->addRecommendation(


### PR DESCRIPTION
Now opcache, wincache shows "OK" as PHP Accelerators (when present and enabled)
Updated check method, cloning the funcionality used in HttpKernel (ConfigDataCollector.php)

The same fix should be made in:
Repository: sensiolabs/SensioDistributionBundle
File: Resources/skeleton/app/SymfonyRequirements.php

To avoid the recomendation triggered by:

``` php
$this->addRecommendation(
    file_get_contents(__FILE__) === file_get_contents(__DIR__.'/../vendor/sensio/distribution-bundle/Sensio/Bundle/DistributionBundle/Resources/skeleton/app/SymfonyRequirements.php'),
    'Requirements file should be up-to-date',
    'Your requirements file is outdated. Run composer install and re-check your configuration.'
);
```
