### PR TITLE
made browser logs commented by defaults (refs symfony/symfony#8413)

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -20,12 +20,14 @@ monolog:
         console:
             type:   console
             bubble: false
-        firephp:
-            type:   firephp
-            level:  info
-        chromephp:
-            type:   chromephp
-            level:  info
+        # uncomment to get logging in your browser
+        # you may have to allow bigger header sizes in your Web server configuration
+        #firephp:
+        #    type:   firephp
+        #    level:  info
+        #chromephp:
+        #    type:   chromephp
+        #    level:  info
 
 assetic:
     use_controller: true


### PR DESCRIPTION
FirePHP and ChromePHP are now disabled by default as they can make the application broke if the web server is not configured with large header sizes.

see symfony/symfony#8413
