### PR TITLE
Unregister initial loader when using ApcClassLoader

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -9,8 +9,9 @@ $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
 // Change 'sf2' to a unique prefix in order to prevent cache key conflicts
 // with other applications also using APC.
 /*
-$loader = new ApcClassLoader('sf2', $loader);
-$loader->register(true);
+$apcLoader = new ApcClassLoader('sf2', $loader);
+$loader->unregister();
+$apcLoader->register(true);
 */
 
 require_once __DIR__.'/../app/AppKernel.php';


### PR DESCRIPTION
I think it's quite bad to have twice the same loader registered because for autoloading classes (or class_exists calls) not handled by the main symfony/composer loader, it'll be called twice.
