### PR TITLE
Update phpDoc to make it standard compliant

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -4,7 +4,7 @@ use Doctrine\Common\Annotations\AnnotationRegistry;
 use Composer\Autoload\ClassLoader;
 
 /**
- * @var $loader ClassLoader
+ * @var ClassLoader $loader
  */
 $loader = require __DIR__.'/../vendor/autoload.php';
 


### PR DESCRIPTION
PHP Doc stipulates that for `@var` comments, the type should come first (see http://en.wikipedia.org/wiki/PHPDoc#Tags)
