### PR TITLE
Updated the profiler configuration for the 2.3 changes

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -6,7 +6,7 @@ framework:
     session:
         storage_id: session.storage.mock_file
     profiler:
-        enabled: false
+        collect: false
 
 web_profiler:
     toolbar: false


### PR DESCRIPTION
FrameworkBundle 2.3 changed the way to configure the profiler, and keeping the old configuration does not allow using `$client->enableProfiler()` in tests.

This is related to https://github.com/symfony/symfony/issues/8541
