### PR TITLE
Fix doctrine common dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "php": ">=5.3.3",
         "symfony/symfony": "2.3.*",
         "doctrine/orm": ">=2.2.3,<2.4-dev",
+        "doctrine/common": ">=2.2.3,<2.4-dev",
         "doctrine/doctrine-bundle": "1.2.*",
         "twig/extensions": "1.0.*",
         "symfony/assetic-bundle": "2.3.*",


### PR DESCRIPTION
After release of Doctrine 2.4 the following versions was installed:
doctrine-orm: 2.3.x
doctrine-dbal: 2.3.x
doctrine-common: 2.4.x

We want the same version of doctrine components. I suggest blocking it on 2.3 for now.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
