### PR TITLE
Remove trailing slash from the end of the URL with a redirect 301

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -7,6 +7,8 @@ DirectoryIndex app.php
 
 <IfModule mod_rewrite.c>
     RewriteEngine On
+    
+    RewriteRule ^(.*)/$ /$1 [L,R=301]
 
     # Determine the RewriteBase automatically and set it as environment variable.
     # If you are using Apache aliases to do mass virtual hosting or installed the


### PR DESCRIPTION
This would be very usefull to fix those URLs that are misspelled but I'm not really sure if this change can broke some other behaviours.
What do you think about it?
