### PR TITLE
Added config to force Symfony use native session handler by default

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -17,7 +17,9 @@ framework:
         #assets_version: SomeVersionScheme
     default_locale:  "%locale%"
     trusted_proxies: ~
-    session:         ~
+    session:
+        # handler_id set to null will use default session handler from php.ini
+        handler_id:  ~
     fragments:       ~
     http_method_override: true
 


### PR DESCRIPTION
As far as I know Symfony is using NativeFileSessionHandler to save session data to file. This breaks server configuration, because if php is configured to use Memcache or Redis session handler, symfony stores session data to file in app/cache directory and ignores default php session settings.

Correct me if I am wrong, but Symfony should use native session handler that is configured in php ini settings by default (to create less WTFs).
