### PR TITLE
Swiftmailer notation changed to Swift Mailer

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -56,7 +56,7 @@ doctrine:
         auto_generate_proxy_classes: %kernel.debug%
         auto_mapping: true
 
-# Swiftmailer Configuration
+# Swift Mailer Configuration
 swiftmailer:
     transport: %mailer_transport%
     host:      %mailer_host%


### PR DESCRIPTION
Minor notation fix according to this commit from documentation:
https://github.com/symfony/symfony-docs/commit/d2671cac093c981bec8995e1413008ad5c5d3aad
