### PR TITLE
Backport issue 426 / PR 429 to master

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -79,7 +79,7 @@ a link cannot be generated):
 
     framework:
         router:
-            strict_requirements: %kernel.debug%
+            strict_requirements: "%kernel.debug%"
 
 You can even disable the requirements check on production with `null` as you should
 know that the parameters for URL generation always pass the requirements, e.g. by
@@ -90,7 +90,7 @@ The `default_locale` parameter is now a setting of the main `framework`
 configuration (it was under the `framework.session` in 2.0):
 
     framework:
-        default_locale: %locale%
+        default_locale: "%locale%"
 
 The `auto_start` setting under `framework.session` must be removed as it is
 not used anymore (the session is now always started on-demand). If

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -4,8 +4,8 @@ imports:
 
 framework:
     #esi:             ~
-    #translator:      { fallback: %locale% }
-    secret:          %secret%
+    #translator:      { fallback: "%locale%" }
+    secret:          "%secret%"
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
         strict_requirements: ~
@@ -23,44 +23,44 @@ framework:
 
 # Twig Configuration
 twig:
-    debug:            %kernel.debug%
-    strict_variables: %kernel.debug%
+    debug:            "%kernel.debug%"
+    strict_variables: "%kernel.debug%"
 
 # Assetic Configuration
 assetic:
-    debug:          %kernel.debug%
+    debug:          "%kernel.debug%"
     use_controller: false
     bundles:        [ ]
     #java: /usr/bin/java
     filters:
         cssrewrite: ~
         #closure:
-        #    jar: %kernel.root_dir%/Resources/java/compiler.jar
+        #    jar: "%kernel.root_dir%/Resources/java/compiler.jar"
         #yui_css:
-        #    jar: %kernel.root_dir%/Resources/java/yuicompressor-2.4.7.jar
+        #    jar: "%kernel.root_dir%/Resources/java/yuicompressor-2.4.7.jar"
 
 # Doctrine Configuration
 doctrine:
     dbal:
-        driver:   %database_driver%
-        host:     %database_host%
-        port:     %database_port%
-        dbname:   %database_name%
-        user:     %database_user%
-        password: %database_password%
+        driver:   "%database_driver%"
+        host:     "%database_host%"
+        port:     "%database_port%"
+        dbname:   "%database_name%"
+        user:     "%database_user%"
+        password: "%database_password%"
         charset:  UTF8
         # if using pdo_sqlite as your database driver, add the path in parameters.yml
-        # e.g. database_path: %kernel.root_dir%/data/data.db3
-        # path:     %database_path%
+        # e.g. database_path: "%kernel.root_dir%/data/data.db3"
+        # path:     "%database_path%"
 
     orm:
-        auto_generate_proxy_classes: %kernel.debug%
+        auto_generate_proxy_classes: "%kernel.debug%"
         auto_mapping: true
 
 # Swiftmailer Configuration
 swiftmailer:
-    transport: %mailer_transport%
-    host:      %mailer_host%
-    username:  %mailer_user%
-    password:  %mailer_password%
+    transport: "%mailer_transport%"
+    host:      "%mailer_host%"
+    username:  "%mailer_user%"
+    password:  "%mailer_password%"
     spool:     { type: memory }

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -15,7 +15,7 @@ monolog:
     handlers:
         main:
             type:   stream
-            path:   %kernel.logs_dir%/%kernel.environment%.log
+            path:   "%kernel.logs_dir%/%kernel.environment%.log"
             level:  debug
         console:
             type:   console

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -19,7 +19,7 @@ monolog:
             handler:      nested
         nested:
             type:  stream
-            path:  %kernel.logs_dir%/%kernel.environment%.log
+            path:  "%kernel.logs_dir%/%kernel.environment%.log"
             level: debug
         console:
             type:  console


### PR DESCRIPTION
Yaml config files into `app/config` are not valid

This issue has already been reported one year ago with issue #426, and has been fixed thanks to PR #429
However, it seems that this PR has been merged into branch 2.1, and not backported into master

Therefore this bug still exists in master, 2.2, 2.3 and 2.4

Here is a PR to merge into master (and it would need a backport into 2.3 and 2.4 at least ?, and maybe a new tag for each)

The fact is I need to parse those yaml files with a Node.js module, and it just throws an error, because of this invalidity
