### PR TITLE
Allow Doctrine 2.4 to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/symfony": "2.3.*",
-        "doctrine/orm": ">=2.2.3,<2.4-dev",
+        "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "1.2.*",
         "twig/extensions": "1.0.*",
         "symfony/assetic-bundle": "2.3.*",


### PR DESCRIPTION
The commit https://github.com/symfony/symfony-standard/commit/0cafa504b6d1235c901d127da01c996219341e6c#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780, lets Doctrine 2.4 installable

But it has been performed only on `master`, `2.4`

Any reason why it shouldn't also be backported to last stable version of `symfony-standard` (`2.3`) ?
