### PR TITLE
Fixed PHPUnit doc URL

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
+<!-- http://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit
     backupGlobals               = "false"
     backupStaticAttributes      = "false"


### PR DESCRIPTION
Any links to `www.phpunit.de` now redirects to the front page. Stripping `www.` off fixes the issue.
