### PR TITLE
Removed PHPunit default parameters

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -3,13 +3,7 @@
 <!-- http://www.phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit
     backupGlobals               = "false"
-    backupStaticAttributes      = "false"
     colors                      = "true"
-    convertErrorsToExceptions   = "true"
-    convertNoticesToExceptions  = "true"
-    convertWarningsToExceptions = "true"
-    processIsolation            = "false"
-    stopOnFailure               = "false"
     syntaxCheck                 = "false"
     bootstrap                   = "bootstrap.php.cache" >
 


### PR DESCRIPTION
Removed PHPUnit's config parameters which values have been set to the default ones.

If developers want to customize it, they already have the link to the doc, and in my experience no newcomers change those anyway. Keeping the file shorter can only make it more accessible.
