### PR TITLE
Enabled translator by default

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -4,7 +4,7 @@ imports:
 
 framework:
     #esi:             ~
-    #translator:      { fallback: "%locale%" }
+    translator:      { fallback: "%locale%" }
     secret:          "%secret%"
     router:
         resource: "%kernel.root_dir%/config/routing.yml"


### PR DESCRIPTION
I found that when newcomers want to use translation, they struggle with the fact that it isn't enable be default. See: http://stackoverflow.com/questions/19147337/symfony-translations-not-working.
This is mainly because there's no error whatsoever.

Enabling it by default might make it easier. On the other hand it might impact performances, but I guess by the time you come to performance issues you're no longer a newcomer :) .
