### PR TITLE
move "dev" bundles to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,12 @@
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.4",
-        "sensio/distribution-bundle": "~2.3",
         "sensio/framework-extra-bundle": "~2.3",
-        "sensio/generator-bundle": "~2.3",
         "incenteev/composer-parameter-handler": "~2.0"
+    },
+    "require-dev": {
+        "sensio/distribution-bundle": "~2.3",
+        "sensio/generator-bundle": "~2.3"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
SensioDistribuitionBundle and SensioGeneratorBundle are not used in production (in AppKernel, they are explicitly active only in dev/test environments). So, they should be in "require-dev" section of composer, to avoid unnecessary downloads in production.
