### PR TITLE
Allow access to app_dev.php whith PHP's dev webserver

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -11,7 +11,7 @@ use Symfony\Component\Debug\Debug;
 // Feel free to remove this, extend it, or make something more sophisticated.
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1'))
+    || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1')) || php_sapi_name() === 'cli-server')
 ) {
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

If you use Vagrant, you can use PHP's built-in webserver like so:

```
app/console server:run 0.0.0.0:8000
```

With Vagrant port-forwarding you can access the application at http://localhost:8000/. The `0.0.0.0:8000` makes PHP listen to IP addresses other than 127.0.0.1.

However `app_dev.php` will forbid access to any IP other than `127.0.0.1`, which makes it unusable.

This is a simple fix to allow access to `app_dev.php` when running on PHP's built-in webserver.
