### PR TITLE
SymfonyRequirements.php: add filter requirement

### DIFF
--- a/app/SymfonyRequirements.php
+++ b/app/SymfonyRequirements.php
@@ -463,6 +463,12 @@ class SymfonyRequirements extends RequirementCollection
         );
 
         $this->addRequirement(
+            function_exists('filter_var'),
+            'filter_var() must be available',
+            'Install and enable the <strong>filter</strong> extension.'
+        );
+
+        $this->addRequirement(
             function_exists('token_get_all'),
             'token_get_all() must be available',
             'Install and enable the <strong>Tokenizer</strong> extension.'


### PR DESCRIPTION
filter extension should be enabled, or you may get such error when validating:

UndefinedFunctionException: Attempted to call function "filter_var" from namespace "Symfony\Component\Validator\Constraints"
