### PR TITLE
Default all requests to HTTP 500.

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -3,10 +3,6 @@
 use Symfony\Component\ClassLoader\ApcClassLoader;
 use Symfony\Component\HttpFoundation\Request;
 
-// Default all requests to HTTP 500. If a fatal error is raised, this will report the correct status code to the client.
-// Subsequent code is responsible for overriding the status code with the desired valued.
-header("HTTP/1.1 500 Internal Server Error", true, 500);
-
 $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
 
 // Use APC for autoloading to improve performance.


### PR DESCRIPTION
When php exits after a fatal error, the output is sent to the browser as a HTTP 200. That is of course problematic with ajax, as the client has no idea the response has failed. 

With this patch, all responses are 500 by default. Subsequent code is responsible for overriding the status code with the desired valued. That should not be a problem, as all requests in Symfony are handled by controllers that return Response objects. 

Unit testing this seems pointless. I did try it on our code base for a day or two, and couldn't find any problems, so I think this is a non-breaking change. 
