### PR TITLE
Improved app/check.php output

### DIFF
--- a/app/check.php
+++ b/app/check.php
@@ -6,7 +6,7 @@ $symfonyRequirements = new SymfonyRequirements();
 
 $iniPath = $symfonyRequirements->getPhpIniConfigPath();
 
-if (is_callable('exec') && $columns = (int)exec('tput cols')) {
+if (is_callable('exec') && $columns = (int) exec('tput cols')) {
     define('CLI_COLUMNS', $columns);
 } else {
     define('CLI_COLUMNS', 80);


### PR DESCRIPTION
```
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | n/a
| Fixed tickets | none
| License       | MIT
| Doc PR        | none
```

This pull request propose a more readable output for app/check.php

For the purpose of the screenshots, I enabled all "help text", (those preceded with a pipe, actually displayed only on warning/error)
## Before:

![app_check_before](https://cloud.githubusercontent.com/assets/19408/2808730/a91449e6-cd41-11e3-86ca-f0a5c7a14ec8.png)
## After:

![app_check_after](https://cloud.githubusercontent.com/assets/19408/2808731/a9148956-cd41-11e3-8469-fb35c1424e2e.png)
