### PR TITLE
Run $kernel->terminate after connection is closed in HHVM

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -27,13 +27,10 @@ $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();
 
-$postSend = function() use ($kernel, $request, $response) {
-    $kernel->terminate($request, $response);
-};
-
 if (function_exists('register_postsend_function')) {
-    register_postsend_function($postSend);
-}
-else {
-    $postSend();
+    register_postsend_function(function() use ($kernel, $request, $response) {
+        $kernel->terminate($request, $response);
+    });
+} else {
+    $kernel->terminate($request, $response);
 }

--- a/web/app.php
+++ b/web/app.php
@@ -28,7 +28,7 @@ $response = $kernel->handle($request);
 $response->send();
 
 if (function_exists('register_postsend_function')) {
-    register_postsend_function(function() use ($kernel, $request, $response) {
+    register_postsend_function(function () use ($kernel, $request, $response) {
         $kernel->terminate($request, $response);
     });
 } else {

--- a/web/app.php
+++ b/web/app.php
@@ -26,4 +26,14 @@ $kernel->loadClassCache();
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();
-$kernel->terminate($request, $response);
+
+$postSend = function() use ($kernel, $request, $response) {
+    $kernel->terminate($request, $response);
+};
+
+if (function_exists('register_postsend_function')) {
+    register_postsend_function($postSend);
+}
+else {
+    $postSend();
+}

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -29,7 +29,7 @@ $response = $kernel->handle($request);
 $response->send();
 
 if (function_exists('register_postsend_function')) {
-    register_postsend_function(function() use ($kernel, $request, $response) {
+    register_postsend_function(function () use ($kernel, $request, $response) {
         $kernel->terminate($request, $response);
     });
 } else {

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -27,4 +27,14 @@ $kernel->loadClassCache();
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();
-$kernel->terminate($request, $response);
+
+$postSend = function() use ($kernel, $request, $response) {
+    $kernel->terminate($request, $response);
+};
+
+if (function_exists('register_postsend_function')) {
+    register_postsend_function($postSend);
+}
+else {
+    $postSend();
+}

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -28,13 +28,10 @@ $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();
 
-$postSend = function() use ($kernel, $request, $response) {
-    $kernel->terminate($request, $response);
-};
-
 if (function_exists('register_postsend_function')) {
-    register_postsend_function($postSend);
-}
-else {
-    $postSend();
+    register_postsend_function(function() use ($kernel, $request, $response) {
+        $kernel->terminate($request, $response);
+    });
+} else {
+    $kernel->terminate($request, $response);
 }


### PR DESCRIPTION
In php-fpm, we can run cleanup code/blocking tasks after the HTTP connection is closed with `fastcgi_finish_request`. HHVM doesn't have this function, but it does have the counterpart `register_postsend_function`.

See here:
https://github.com/facebook/hhvm/blob/master/hphp/doc/extension.new_functions
https://github.com/facebook/hhvm/issues/1230

Note: haven't tested yet. Just putting it out there.