### PR TITLE
Add phpunit.xml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /app/logs/*
 !app/cache/.gitkeep
 !app/logs/.gitkeep
+/app/phpunit.xml
 /build/
 /vendor/
 /bin/


### PR DESCRIPTION
[The documentation](http://symfony.com/doc/current/book/testing.html#phpunit-configuration) recommends ignoring `phpunit.xml`, and only committing `phpunit.xml.dist` in version control.

This PR adds `/app/phpunit.xml` to the `.gitignore` that comes with the Symfony Standard distribution.
