### PR TITLE
More readable results of the check requirement in console

### DIFF
--- a/app/check.php
+++ b/app/check.php
@@ -49,14 +49,19 @@ function echo_requirement(Requirement $requirement)
 {
     $result = $requirement->isFulfilled() ? 'OK' : ($requirement->isOptional() ? 'WARNING' : 'ERROR');
     echo ' ' . str_pad($result, 9);
-    echo $requirement->getTestMessage() . "\n";
+    echo wrap_line($requirement->getTestMessage()) . "\n";
 
     if (!$requirement->isFulfilled()) {
-        echo sprintf("          %s\n\n", $requirement->getHelpText());
+        echo sprintf("          %s\n\n", wrap_line($requirement->getHelpText()));
     }
 }
 
 function echo_title($title)
 {
     echo "\n** $title **\n\n";
+}
+
+function wrap_line($text, $size=70)
+{
+    return wordwrap($text, $size, "\n          ");
 }


### PR DESCRIPTION
The result column and the explanation one don't get mixed anymore.
The line is wrapped at 70 character (default console size minus the padding of the result column).
