### PR TITLE
[WIP][DX] Automatic registration of installed bundles

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -22,6 +22,7 @@ class AppKernel extends Kernel
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
+            $bundles[] = new Gnugat\Bundle\WizardBundle\GnugatWizardBundle();
         }
 
         return $bundles;

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "symfony/monolog-bundle": "~2.4",
         "sensio/distribution-bundle": "~3.0",
         "sensio/framework-extra-bundle": "~3.0",
-        "incenteev/composer-parameter-handler": "~2.0"
+        "incenteev/composer-parameter-handler": "~2.0",
+        "gnugat/wizard-plugin": "~1.0"
     },
     "require-dev": {
         "sensio/generator-bundle": "~2.3"


### PR DESCRIPTION
As discussed [here](https://github.com/symfony/symfony/issues/6082#issuecomment-51579210), this PR integrates the Wizard Bundle in the Standard Edition.

On each `composer require ...`, this library will:

1. check if the package is a bundle
2. convert the package name into a fully qualified classname (FCQN)
3. insert the FQCN in the `AppKernel` (if not already registered)

It depends on a Bundle which provides a the two following commands:

* `wizard:register:bundle`: registers the given FCQN in the `AppKernel` (useful when a bundle has been created manually)
* `wizard:register:package`: converts the given package name into a FCQN and registers it in the `AppKernel` (useful when a bundle has been unregistered, but is still installed, and needs to be enabled again)