### PR TITLE
When installing Symfony, the parameters.yml is now generated automatically

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         ],
         "post-install-cmd": [
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::generateParametersFile",
+            "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #691 |
| License | MIT |
| Doc PR | - |

**WARNING** This change depends on this other change made on SensioDistributionBundle: https://github.com/sensiolabs/SensioDistributionBundle/pull/155
