### PR TITLE
[Console] filter doctrine log with -vv cli option

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -20,6 +20,18 @@ monolog:
         console:
             type:   console
             bubble: false
+            verbosity_levels:
+                VERBOSITY_VERBOSE: INFO
+                VERBOSITY_VERY_VERBOSE: DEBUG
+            channels: ["!doctrine"]
+        console_very_verbose:
+            type:   console
+            bubble: false
+            verbosity_levels:
+                VERBOSITY_VERBOSE: NOTICE
+                VERBOSITY_VERY_VERBOSE: NOTICE
+                VERBOSITY_DEBUG: DEBUG
+            channels: ["doctrine"]
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration
         #firephp:


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | none |

I add this configuration to all my projects. So I think it could be the default
behavior fore everyone.

Why?

When you write commands and you use lot of log in your application with the
`debug` log level; you have to use `-vvv` option to see them. But with
`-vvv``option, doctrine log is also output. This is a bit annoying because it
becomes very hard to filter your log from doctrine log.

How?

So with this patch you get all logs with `debug` or higher log level, except
doctrine log with `vv` option. And you get all logs with `-vvv` option. With
only `-v` option, you get only `info` or higher log level.
