### PR TITLE
Improve pdo_sqlite using info

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -52,10 +52,12 @@ doctrine:
         user:     "%database_user%"
         password: "%database_password%"
         charset:  UTF8
-        # if using pdo_sqlite as your database driver, add the path in parameters.yml
-        # e.g. database_path: "%kernel.root_dir%/data/data.db3"
-        # and uncomment next line:
-        # path:     "%database_path%"
+        # if using pdo_sqlite as your database driver:
+        #   1. add the path in parameters.yml
+        #     e.g. database_path: "%kernel.root_dir%/data/data.db3"
+        #   2. Uncomment database_path in parameters.yml.dist
+        #   3. Uncomment next line:
+        #     path:     "%database_path%"
 
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -5,6 +5,8 @@ parameters:
     database_name:     symfony
     database_user:     root
     database_password: ~
+    # You should uncomment this if you want use pdo_sqlite
+    # database_path: "%kernel.root_dir%/data.db3"
 
     mailer_transport:  smtp
     mailer_host:       127.0.0.1


### PR DESCRIPTION
1. Line with `path` declaration should be uncommented in config.yml for use `database_path`
2. Line with `database_path` declaration should be uncommented in parameters.yml.dist, because any composer commands (which call `post-install-cmd` or `post-update-cmd`) remove `database_path` from parameters.yml
