### PR TITLE
[Security][Proposal][WIP] Deny explicit requests to app.php/

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -3,6 +3,20 @@
 use Symfony\Component\ClassLoader\ApcClassLoader;
 use Symfony\Component\HttpFoundation\Request;
 
+// This check prevents explicit access to front controller, except while Apache
+// mod_rewrite fallback
+// Feel free to remove this, extend it, or make something more sophisticated.
+if (preg_match('#^/(.[^/]+)#', $_SERVER['REQUEST_URI'], $matches)
+    && $_SERVER['SCRIPT_NAME'] === $matches[0]
+) {
+    if (false === stripos($_SERVER['SERVER_SOFTWARE'], 'apache')
+        || (function_exists('apache_get_modules') && in_array('mod_rewrite', apache_get_modules()))
+    ) {
+        header('HTTP/1.0 404 Not found');
+        exit();
+    }
+}
+
 $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
 
 // Enable APC for autoloading to improve performance.


### PR DESCRIPTION
Added check in app.php front controller in order to avoid explicit requests
being served by PROD env, except while Apache mod_alias redirect fallback.

Before:

```
GET http://localhost:8000/app.php/demo/hello/Fabien
HTTP/1.0 200 OK
```

After:

```
GET http://localhost:8000/app.php/demo/hello/Fabien
HTTP/1.0 404 Not found
```

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Doc PR |  |

This approach tries to help with the obscurity about which framework is used in the app (app.php is publicly known as Symfony's front controller).
It's a proposal, any suggestion or comment are welcome.
