### PR TITLE
Fixes the date_default_time_get() error .

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -5,6 +5,12 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 
 class AppKernel extends Kernel
 {
+    
+   public function init()
+    {
+        date_default_timezone_set( 'Europe/Lisbon' );
+    }
+    
     public function registerBundles()
     {
         $bundles = array(


### PR DESCRIPTION
Warning: date_default_timezone_get(): It is not safe to rely on the system's timezone settings. You are _required_ to use the date.timezone setting or the date_default_timezone_set() function.

This fixes it and doesn't effect the machine either mac or windows.
