### PR TITLE
install assets as symlink

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
     "extra": {
         "symfony-app-dir": "app",
         "symfony-web-dir": "web",
+        "symfony-assets-install": "relative",
         "incenteev-parameters": {
             "file": "app/config/parameters.yml"
         },


### PR DESCRIPTION
This is now safe because it will fallback to hard copies since symfony 2.6.
