### PR TITLE
Enable the Serializer

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -13,6 +13,7 @@ framework:
     form:            ~
     csrf_protection: ~
     validation:      { enable_annotations: true }
+    serializer:      { enabled: true }
     templating:
         engines: ['twig']
         #assets_version: SomeVersionScheme


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | ~ |

With symfony/symfony#12295, the Serializer is fully functional and can be enabled by default.
Enabling it in the standard edition avoid BC.
