### PR TITLE
fix .htaccess for apache to v2.2 or 2.3 and later

### DIFF
--- a/app/.htaccess
+++ b/app/.htaccess
@@ -1,5 +1,13 @@
 <IfModule mod_authz_core.c>
-    Require all denied
+    <IfModule mod_authz_host.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_host.c>
+        <IfModule mod_access_compat.c>
+            Order deny,allow
+            Deny from all
+        </IfModule>
+    </IfModule>
 </IfModule>
 <IfModule !mod_authz_core.c>
     Order deny,allow

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -1,5 +1,13 @@
 <IfModule mod_authz_core.c>
-    Require all denied
+    <IfModule mod_authz_host.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_host.c>
+        <IfModule mod_access_compat.c>
+            Order deny,allow
+            Deny from all
+        </IfModule>
+    </IfModule>
 </IfModule>
 <IfModule !mod_authz_core.c>
     Order deny,allow


### PR DESCRIPTION
mod_authz_core is authorization core, but the responsible of allow/deny access to host/ip/... is mod_authz_host or for compatibility reasons mod_access_compat, this is a reasonable aproach for a variety of installations.