### PR TITLE
Remove unused twig-extensions dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
         "symfony/symfony": "2.3.*",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "1.2.*",
-        "twig/extensions": "1.0.*",
         "symfony/assetic-bundle": "2.3.*",
         "symfony/swiftmailer-bundle": "2.3.*",
         "symfony/monolog-bundle": "2.3.*",


### PR DESCRIPTION
The `twig/extensions` library is not actually used or enabled in the symfony standard distribution so its inclusion in the composer.json file seems unnecessary. I did quite a bit of digging around to work out why it was ever included and as best I can tell it was because in the betas of `2.0` there was a convenient way to register these extensions in the twig configuration block. That approach was abandoned in https://github.com/symfony/symfony/commit/96045739b198b030ab159425ce19614fe2e0e665 
