### PR TITLE
Switch 2.6 dependency to stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony": "2.6.x-dev",
+        "symfony/symfony": "2.6.*",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2",
         "twig/extensions": "~1.0",


### PR DESCRIPTION
symfony/symfony dependency needs to be stabilized on 2.6 because right now a fresh stable install fetches 2.6.x-dev.

```
$ composer create-project symfony/framework-standard-edition src --prefer-dist
Installing symfony/framework-standard-edition (v2.6.0)
  - Installing symfony/framework-standard-edition (v2.6.0)

...

  - Installing symfony/symfony (2.6.x-dev 5b6a95c)
    Downloading: 100%
```
