### PR TITLE
Updated checks for localhost to extend to RFC1918 too

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -9,12 +9,16 @@ use Symfony\Component\Debug\Debug;
 
 // This check prevents access to debug front controllers that are deployed by accident to production servers.
 // Feel free to remove this, extend it, or make something more sophisticated.
-if (isset($_SERVER['HTTP_CLIENT_IP'])
-    || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1')) || php_sapi_name() === 'cli-server')
-) {
-    header('HTTP/1.0 403 Forbidden');
-    exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
+$ip_sources= array('HTTP_CLIENT_IP', 'HTTP_FORWARDED','HTTP_FORWARDED_FOR','HTTP_X_FORWARDED', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_CLUSTER_CLIENT_IP','REMOTE_ADDR');
+foreach($ip_sources as $ip) {
+    if (array_key_exists($key, $_SERVER) === true) {
+        foreach (explode(',', $_SERVER[$key]) as $sub_ip) {
+            if(filter_var($sub_ip,FILTER_VALIDATE_IP,FILTER_FLAG_NO_PRIV_RANGE|FILTER_FLAG_NO_RES_RANGE)) {
+                header('HTTP/1.0 403 Forbidden');
+		exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
+            }
+        }
+   }
 }
 
 $loader = require_once __DIR__.'/../app/bootstrap.php.cache';

--- a/web/config.php
+++ b/web/config.php
@@ -4,12 +4,16 @@ if (!isset($_SERVER['HTTP_HOST'])) {
     exit('This script cannot be run from the CLI. Run it from a browser.');
 }
 
-if (!in_array(@$_SERVER['REMOTE_ADDR'], array(
-    '127.0.0.1',
-    '::1',
-))) {
-    header('HTTP/1.0 403 Forbidden');
-    exit('This script is only accessible from localhost.');
+$ip_sources= array('HTTP_CLIENT_IP', 'HTTP_FORWARDED','HTTP_FORWARDED_FOR','HTTP_X_FORWARDED', 'HTTP_X_FORWARDED_FOR', 'HTTP_X_CLUSTER_CLIENT_IP','REMOTE_ADDR');
+foreach($ip_sources as $ip) {
+    if (array_key_exists($key, $_SERVER) === true) {
+        foreach (explode(',', $_SERVER[$key]) as $sub_ip) {
+            if(filter_var($sub_ip,FILTER_VALIDATE_IP,FILTER_FLAG_NO_PRIV_RANGE|FILTER_FLAG_NO_RES_RANGE)) {
+                header('HTTP/1.0 403 Forbidden');
+                exit('This script is only accessible from localhost.');
+            }
+        }
+   }
 }
 
 require_once dirname(__FILE__).'/../app/SymfonyRequirements.php';


### PR DESCRIPTION
Currently, you only check for localhost usage.

It may well be people are running in a console-only VM or on a server, in which case, allowing requests from RFC1918 or reserved subnets would be desirable.

The goal of this patch is to allow this to happen for app_dev.php and config.php.
