### PR TITLE
Fixed SensioDistributionBundle requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.4",
-        "sensio/distribution-bundle": "~3.0",
+        "sensio/distribution-bundle": "~3.0.12",
         "sensio/framework-extra-bundle": "~3.0",
         "incenteev/composer-parameter-handler": "~2.0"
     },


### PR DESCRIPTION
The 3.0.12 version introduces the `removeSymfonyStandardFiles` method in `Sensio\Bundle\DistributionBundle\Composer\ScriptHandler` which is required for the `post-install` and `post-update` scripts.

When the cURL PHP extension is not installed, Composer will install the 3.0.11 version of SensioDistributionBundle which don't depends on cURL, but the scripts requiring the `removeSymfonyStandardFiles` method will fail.

By requiring at least the 3.0.12 version, we ensure Composer will abort with an helpful error, saying that `ext-curl` needs to be installed.

Before:

```
Method Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::removeSymfonyStandardFiles is not callable, can not call post-install-cmd script
```

After:

```
Your requirements could not be resolved to an installable set of packages.

Problem 1
    - sensiolabs/security-checker v2.0.0 requires ext-curl * -> the requested PHP extension curl is missing from your system.
    - sensio/distribution-bundle v3.0.12 requires sensiolabs/security-checker ~2.0 -> satisfiable by sensiolabs/security-checker[v2.0.0].
    - Installation request for sensio/distribution-bundle ~3.0.12 -> satisfiable by sensio/distribution-bundle[v3.0.12].
```
