### PR TITLE
The localhost checks now include the host loopback 10.0.2.2

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -11,7 +11,7 @@ use Symfony\Component\Debug\Debug;
 // Feel free to remove this, extend it, or make something more sophisticated.
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1'))
+    || !in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', '10.0.2.2', 'fe80::1', '::1'))
 ) {
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');

--- a/web/config.php
+++ b/web/config.php
@@ -6,6 +6,8 @@ if (!isset($_SERVER['HTTP_HOST'])) {
 
 if (!in_array(@$_SERVER['REMOTE_ADDR'], array(
     '127.0.0.1',
+    '10.0.2.2',
+    'fe80::1',
     '::1',
 ))) {
     header('HTTP/1.0 403 Forbidden');


### PR DESCRIPTION
This makes things a little easier for those developing Symfony applications with Vagrant. I have added the host loopback address 10.0.2.2 to the allowed localhost addresses. This provides access to  `web/app_dev.php` and `web/config.php` (_regenerated on each `composer update`_) to developers writing applications inside of a virtual machine.