### PR TITLE
Use getRootDir() rather than assuming __DIR__

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -31,6 +31,6 @@ class AppKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
-        $loader->load(__DIR__.'/config/config_'.$this->getEnvironment().'.yml');
+        $loader->load($this->getRootDir().'/config/config_'.$this->getEnvironment().'.yml');
     }
 }


### PR DESCRIPTION
In the event that `getRootDir()` in `AppKernel` is overridden (eg the file is moved elsewhere but the config etc stays put), the `registerContainerConfiguration` would also have to be changed.