### PR TITLE
Add preview error route to dev firewall

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -5,7 +5,7 @@ security:
 
     firewalls:
         dev:
-            pattern: ^/(_(profiler|wdt)|css|images|js)/
+            pattern: ^/(_(profiler|wdt|error)|css|images|js)/
             security: false
 
         default:


### PR DESCRIPTION
Add the `_error` route to preview error pages to the dev firewall, so you don't have to be authenticated to preview error pages
