### PR TITLE
Adding security advisories pre-update check via `roave/security-advisories` meta-package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "symfony/monolog-bundle": "~2.4",
         "sensio/distribution-bundle": "~3.0,>=3.0.12",
         "sensio/framework-extra-bundle": "~3.0,>=3.0.2",
-        "incenteev/composer-parameter-handler": "~2.0"
+        "incenteev/composer-parameter-handler": "~2.0",
+        "roave/security-advisories": "dev-master"
     },
     "require-dev": {
         "sensio/generator-bundle": "~2.3"


### PR DESCRIPTION
This additional package behaves like https://github.com/FriendsOfPHP/security-advisories, but before actually running the installation during any `require` or `update` composer command executions.

This effectively prevents installation of any security-issue affected code when changing dependencies.

The package itself does not bring in any dependencies or any additional code.

_must_ be referencing `dev-master`.

More on it:
- https://github.com/Roave/SecurityAdvisories
- [Roave/SecurityAdvisories release blogpost](http://ocramius.github.io/blog/roave-security-advisories-protect-against-composer-packages-with-security-issues/)

I didn't update the `composer.lock` since I'd first need some feedback on whether this change is actually welcome.
