### PR TITLE
Excluding files from tests from bundle without vendors

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -29,6 +29,8 @@
                 <directory>../src/*/*Bundle/Tests</directory>
                 <directory>../src/*/Bundle/*Bundle/Resources</directory>
                 <directory>../src/*/Bundle/*Bundle/Tests</directory>
+                <directory>../src/*Bundle/Resources</directory>
+                <directory>../src/*Bundle/Tests</directory>
             </exclude>
         </whitelist>
     </filter>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | - |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

minor - I have added to phpunit.xml.dist Tests & Resources directories for bundle without vendors, which should be excluded for code coverage too.
