### PR TITLE
Allow environment variables for more flexible dev environment

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -11,7 +11,14 @@ use Symfony\Component\Debug\Debug;
 // Feel free to remove this, extend it, or make something more sophisticated.
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1')) || php_sapi_name() === 'cli-server')
+    ||
+        (
+        !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1')))
+        &&
+        !(in_array(@$_SERVER['REMOTE_ADDR'], explode(',', @$_SERVER['SYMFONY__TRUSTED_HOSTS'])))
+        &&
+        !(php_sapi_name() === 'cli-server')
+        )
 ) {
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -15,7 +15,7 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
         (
         !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1')))
         &&
-        !(in_array(@$_SERVER['REMOTE_ADDR'], array_map('trim', explode(',', @$_SERVER['SYMFONY__TRUSTED_HOSTS']))))
+        !(in_array(@$_SERVER['REMOTE_ADDR'], array_map('trim', explode(',', @$_SERVER['SYMFONY__TRUSTED_CLIENTS'])), true))
         &&
         !(php_sapi_name() === 'cli-server')
         )

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -15,7 +15,7 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
         (
         !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1')))
         &&
-        !(in_array(@$_SERVER['REMOTE_ADDR'], explode(',', @$_SERVER['SYMFONY__TRUSTED_HOSTS'])))
+        !(in_array(@$_SERVER['REMOTE_ADDR'], array_map('trim', explode(',', @$_SERVER['SYMFONY__TRUSTED_HOSTS']))))
         &&
         !(php_sapi_name() === 'cli-server')
         )


### PR DESCRIPTION
Fix to https://github.com/symfony/symfony/issues/11395: his allow developers to define environment variables for more flexible dev environment access in general.
