### PR TITLE
Added a filter to check for local network ip range with php filter_var

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -11,7 +11,10 @@ use Symfony\Component\Debug\Debug;
 // Feel free to remove this, extend it, or make something more sophisticated.
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1')) || php_sapi_name() === 'cli-server')
+    || !(
+        !filter_var(@$_SERVER['REMOTE_ADDR'], FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE) ||
+        in_array(@$_SERVER['REMOTE_ADDR'], array('fe80::1', '::1')
+        ) || php_sapi_name() === 'cli-server')
 ) {
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');


### PR DESCRIPTION
I am really hate then I use Vagrant / Docker dev environment every time I need to go to app_dev.php to add my host IP address to be able access application event then I am on local network IP range.

I think dev environment should be accessed from local network.

For checking if IP is in private network IP ranges I use PHP function `filter_var` and `FILTER_VALIDATE_IP` flag with `FILTER_FLAG_NO_PRIV_RANGE` which checks against IPv4 private network range defined in this [table](http://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces) but it fails validation for the IPv6 addresses starting with FD or FC. I also left the original `in_array` checking for specific IP's.

I also suggest to extract specific IP's array from if clause to separate array variable this will help then having real big list of IP's