### PR TITLE
Prevent doctrine/dbal 2.5 from installing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/symfony": "2.3.*",
-        "doctrine/orm": "~2.2,>=2.2.3",
+        "doctrine/orm": "~2.2,>=2.2.3,<2.5",
+        "doctrine/dbal": "<2.5",
         "doctrine/doctrine-bundle": "1.2.*",
         "twig/extensions": "1.0.*",
         "symfony/assetic-bundle": "2.3.*",


### PR DESCRIPTION
Currently, an incompatibility between ORM 2.4 and DBAL 2.5 causes the post-install-cmd steps to fail in the prod env.
Until a fix is out, it's best to stick to 2.4 for both, so a standard edition project deploys successfully.