### PR TITLE
Move %locale% to config.yml

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -3,6 +3,8 @@ imports:
     - { resource: security.yml }
     - { resource: services.yml }
 
+# Put parameters here that don't need to change on each machine where the app is deployed
+# http://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
 parameters:
     locale: en
 

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -3,6 +3,9 @@ imports:
     - { resource: security.yml }
     - { resource: services.yml }
 
+parameters:
+    locale: en
+
 framework:
     #esi:             ~
     #translator:      { fallback: "%locale%" }

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -51,7 +51,7 @@ assetic:
 # Doctrine Configuration
 doctrine:
     dbal:
-        driver:   "%database_driver%"
+        driver:   pdo_mysql
         host:     "%database_host%"
         port:     "%database_port%"
         dbname:   "%database_name%"

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,4 +1,6 @@
 # This file is a "template" of what your parameters.yml file should look like
+# Set parameters here that may be different on each machine where the app is deployed
+# http://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 parameters:
     database_driver:   pdo_mysql
     database_host:     127.0.0.1

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -14,7 +14,5 @@ parameters:
     mailer_user:       ~
     mailer_password:   ~
 
-    locale:            en
-
     # A secret key that's used to generate certain security-related tokens
     secret:            ThisTokenIsNotSoSecretChangeIt

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -1,8 +1,7 @@
 # This file is a "template" of what your parameters.yml file should look like
-# Set parameters here that may be different on each machine where the app is deployed
+# Set parameters here that may be different on each deployment target of the app, e.g. development, staging, production.
 # http://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 parameters:
-    database_driver:   pdo_mysql
     database_host:     127.0.0.1
     database_port:     ~
     database_name:     symfony


### PR DESCRIPTION
As per the official best practices, parameters.yml should be reserved for infrastrucure-related parameters. The default locale is a parameter which typically is application related, so I suggest moving it to config.yml.