### PR TITLE
Enable assets.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -15,7 +15,7 @@ framework:
     validation:      { enable_annotations: true }
     templating:
         engines: ['twig']
-        #assets_version: SomeVersionScheme
+    assets: ~
     default_locale:  "%locale%"
     trusted_hosts:   ~
     trusted_proxies: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

Re https://github.com/symfony/symfony/pull/13667

This will prevent the following exception when rendering templates:

```
Twig_Error_Syntax in ExpressionParser.php line 568: The function "asset" does not exist in "base.html.twig" at line 7
```