### PR TITLE
Fixed default route path

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -8,7 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 class DefaultController extends Controller
 {
     /**
-     * @Route("/app/example", name="homepage")
+     * @Route("/home", name="homepage")
      */
     public function indexAction()
     {

--- a/src/AppBundle/Tests/Controller/DefaultControllerTest.php
+++ b/src/AppBundle/Tests/Controller/DefaultControllerTest.php
@@ -10,7 +10,7 @@ class DefaultControllerTest extends WebTestCase
     {
         $client = static::createClient();
 
-        $crawler = $client->request('GET', '/app/example');
+        $crawler = $client->request('GET', '/home');
 
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
         $this->assertTrue($crawler->filter('html:contains("Homepage")')->count() > 0);


### PR DESCRIPTION
When using the Apache option `MultiViews` the path `/app` will be resolved to the `/app.php` file by Apache. So `/app/example` will resolve to `/app.php/example` and the application will respond with a 404 because the `/example` route does not exist.

This PR changes the example route to `/home` as it was also proposed in https://github.com/symfony/symfony-standard/issues/758.