### PR TITLE
Send only headers in response to HEAD requests

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -26,5 +26,10 @@ $kernel->loadClassCache();
 //Request::enableHttpMethodParameterOverride();
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
-$response->send();
+
+if ($request->getMethod() == 'HEAD') {
+    $response->sendHeaders();
+} else {
+    $response->send();
+}
 $kernel->terminate($request, $response);

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -26,5 +26,10 @@ $kernel = new AppKernel('dev', true);
 $kernel->loadClassCache();
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
-$response->send();
+
+if ($request->getMethod() == 'HEAD') {
+    $response->sendHeaders();
+} else {
+    $response->send();
+}
 $kernel->terminate($request, $response);


### PR DESCRIPTION
I was surprised to find that this wasn't the case (though I wouldn't be surprised if there's a reason that I'm ignorant of). Per my testing, the routing component already treats HEAD requests like GET requests, so no issues there. I wanted to submit this patch in-case it was just something that had been overlooked and might find useful, or otherwise learn why it's a bad idea.

An alternative implementation might be to return only a HeaderResponse from the kernel when the request method is HEAD (where HeaderResponse is just a null-bodied Response), which would reduce duplication and increase testability. Perhaps also ought to use `Request::HTTP_HEAD`. Feedback welcome!