### PR TITLE
updated deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "incenteev/composer-parameter-handler": "~2.0"
     },
     "require-dev": {
-        "sensio/generator-bundle": "~2.3"
+        "sensio/generator-bundle": "~2.3",
+        "symfony/phpunit-bridge": "2.7.*@dev"
     },
     "scripts": {
         "post-root-package-install": [


### PR DESCRIPTION
Actually user tests fails because the SecurityListener of the framework-extra-bundle still use the deprecated SecurityContext interface.