### PR TITLE
Update ORM requirements to allow DBAL 2.5 again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,14 +9,14 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/symfony": "2.3.*",
-        "doctrine/orm": "~2.2.3||~2.3.0||~2.4.8||~2.5",
+        "doctrine/orm": "^2.4.8",
         "doctrine/doctrine-bundle": "~1.2",
         "twig/extensions": "1.0.*",
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.4",
         "sensio/distribution-bundle": "~2.3",
-        "sensio/framework-extra-bundle": "~3.0,>=3.0.2",
+        "sensio/framework-extra-bundle": "^3.0.2",
         "sensio/generator-bundle": "~2.3",
         "incenteev/composer-parameter-handler": "~2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/symfony": "2.3.*",
-        "doctrine/orm": "~2.2,>=2.2.3,<2.5",
-        "doctrine/dbal": "<2.5",
+        "doctrine/orm": "~2.2.3||~2.3.0||~2.4.8||~2.5",
         "doctrine/doctrine-bundle": "~1.2",
         "twig/extensions": "1.0.*",
         "symfony/assetic-bundle": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "symfony/symfony": "2.3.*",
         "doctrine/orm": "^2.4.8",
         "doctrine/doctrine-bundle": "~1.2",
-        "twig/extensions": "1.0.*",
+        "twig/extensions": "~1.0",
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.4",


### PR DESCRIPTION
@Ocramius could doctrine release ORM 2.4.8 so https://github.com/doctrine/doctrine2/commit/e05930e71482df06982c332b8820a1ae51bd7f28 is tagged? I think orm <2.4.8 is incompatible with DBAL 2.5.