### PR TITLE
Changed ORM default naming strategy to underscore

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -68,6 +68,7 @@ doctrine:
 
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"
+        naming_strategy: doctrine.orm.naming_strategy.underscore
         auto_mapping: true
 
 # Swiftmailer Configuration


### PR DESCRIPTION
This PR partially fixes the problem with case-sensitive identifiers http://dev.mysql.com/doc/refman/5.0/en/identifier-case-sensitivity.html

Replaces https://github.com/doctrine/DoctrineBundle/pull/406