### PR TITLE
[CRITICAL] PSR-4 path to `SymfonyStandard` is incorrect

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "description": "The \"Symfony Standard Edition\" distribution",
     "autoload": {
-        "psr-4": { "": "src/", "SymfonyStandard\\": "app/" }
+        "psr-4": { "": "src/", "SymfonyStandard\\": "app/SymfonyStandard/" }
     },
     "require": {
         "php": ">=5.3.3",


### PR DESCRIPTION
It was simply replaced at 6272b3388862e57f6fd688f06a1d1c9896fd4ffd `psr-0` with `psr-4` but it additionally requires fixing the path to the namespace.