### PR TITLE
[2.6+] Removed AcmeDemoBundle

### DIFF
--- a/app/SymfonyStandard/RootPackageInstallSubscriber.php
+++ b/app/SymfonyStandard/RootPackageInstallSubscriber.php
@@ -18,11 +18,6 @@ use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler;
 
 class RootPackageInstallSubscriber implements EventSubscriberInterface
 {
-    public static function installAcmeDemoBundle(CommandEvent $event)
-    {
-        ScriptHandler::installAcmeDemoBundle($event);
-    }
-
     public static function setupNewDirectoryStructure(CommandEvent $event)
     {
         ScriptHandler::defineDirectoryStructure($event);
@@ -33,7 +28,6 @@ class RootPackageInstallSubscriber implements EventSubscriberInterface
         return array(
             ScriptEvents::POST_INSTALL_CMD => array(
                 array('setupNewDirectoryStructure', 512),
-                array('installAcmeDemoBundle', 0)
             ),
         );
     }

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -1,4 +1,5 @@
 security:
+
     providers:
         in_memory:
             memory: ~
@@ -8,5 +9,5 @@ security:
             pattern: ^/(_(profiler|wdt|error)|css|images|js)/
             security: false
 
-        default:
+        main:
             anonymous: ~


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

This removes the AcmeDemoBundle for Symfony Standard 2.6+.