### PR TITLE
adding light documentation to security.yml

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -1,13 +1,24 @@
+# To get started with security, check out the documentation:
+# http://symfony.com/doc/current/book/security.html
 security:
 
+    # http://symfony.com/doc/current/book/security.html#where-do-users-come-from-user-providers
     providers:
         in_memory:
             memory: ~
 
     firewalls:
+        # disables authentication for assets and the profiler, adapt it according to your needs
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
         main:
             anonymous: ~
+            # activate different ways to authenticate
+
+            # http_basic: ~
+            # http://symfony.com/doc/current/book/security.html#a-configuring-how-your-users-will-authenticate
+
+            # form_login: ~
+            # http://symfony.com/doc/current/cookbook/security/form_login_setup.html


### PR DESCRIPTION
Hi guys!

When we removed AcmeDemoBundle recently, we lost a lot of "example" security configuration that was there before. I realized this in a training - you open this file, but don't know where to go next. I've added some very basic links to help get the user moving.

@javiereguiluz does this make sense to you?

Thanks!