### PR TITLE
Too many arguments for echo_block

### DIFF
--- a/app/check.php
+++ b/app/check.php
@@ -42,9 +42,9 @@ foreach ($symfonyRequirements->getRecommendations() as $req) {
 }
 
 if ($checkPassed) {
-    echo_block('success', 'OK', 'Your system is ready to run Symfony2 projects', true);
+    echo_block('success', 'OK', 'Your system is ready to run Symfony2 projects');
 } else {
-    echo_block('error', 'ERROR', 'Your system is not ready to run Symfony2 projects', true);
+    echo_block('error', 'ERROR', 'Your system is not ready to run Symfony2 projects');
 
     echo_title('Fix the following mandatory requirements', 'red');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

The call to `echo_block()` has too many arguments by adding the `true` as fourth argument. Removed the fourth argument to match function signature.

Not sure to threat it like a bug and propose this PR to the 2.5 branch?