### PR TITLE
Fix Intl recommendation

### DIFF
--- a/app/SymfonyRequirements.php
+++ b/app/SymfonyRequirements.php
@@ -638,7 +638,7 @@ class SymfonyRequirements extends RequirementCollection
         }
 
         $this->addRecommendation(
-            class_exists('Locale'),
+            extension_loaded('intl') && class_exists('Locale'),
             'intl extension should be available',
             'Install and enable the <strong>intl</strong> extension (used for validators).'
         );


### PR DESCRIPTION
I have not installed `php-intl` module on my local machine but  I do not get recommendation to install `php-intl` when check `app/check.php` or `web/config.php` scripts. The `Locale` class exists.

My PHP version is:
```
PHP 5.6.4-4ubuntu6.2 (cli) (built: Jul  2 2015 15:29:28)
Copyright (c) 1997-2014 The PHP Group
Zend Engine v2.6.0, Copyright (c) 1998-2014 Zend Technologies
    with Zend OPcache v7.0.4-dev, Copyright (c) 1999-2014, by Zend Technologies
    with Xdebug v2.2.6, Copyright (c) 2002-2014, by Derick Rethans
```

My PHP modules (`$ php -m`) are:
```
[PHP Modules]
bcmath
bz2
calendar
Core
ctype
curl
date
dba
dom
ereg
exif
fileinfo
filter
ftp
gd
geoip
gettext
hash
iconv
imagick
json
libxml
mbstring
mcrypt
memcache
memcached
mhash
mysql
mysqli
mysqlnd
mysqlnd_ms
OAuth
openssl
pcntl
pcre
PDO
pdo_mysql
pdo_sqlite
Phar
posix
readline
Reflection
session
shmop
SimpleXML
soap
sockets
SPL
sqlite3
standard
sysvmsg
sysvsem
sysvshm
tokenizer
wddx
xdebug
xml
xmlreader
xmlwriter
Zend OPcache
zip
zlib

[Zend Modules]
Xdebug
Zend OPcache
```