### PR TITLE
Use a proper version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "require": {
         "php": ">=5.3.9",
-        "symfony/symfony": "2.8.x-dev",
+        "symfony/symfony": "2.8.*@dev",
         "doctrine/orm": "^2.4.8",
         "doctrine/doctrine-bundle": "~1.4",
         "symfony/assetic-bundle": "~2.3",


### PR DESCRIPTION
Any reason why this wasn't used already? I noticed this when looking at https://github.com/symfony/symfony-standard/pull/850.