### PR TITLE
extract autoloading out from bootstrap

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -3,11 +3,15 @@
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Composer\Autoload\ClassLoader;
 
+error_reporting(error_reporting() & ~E_USER_DEPRECATED);
+
 /**
  * @var ClassLoader $loader
  */
 $loader = require __DIR__.'/../vendor/autoload.php';
 
 AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
+
+include_once __DIR__.'/bootstrap.php.cache';
 
 return $loader;

--- a/app/autoload.php
+++ b/app/autoload.php
@@ -12,6 +12,4 @@ $loader = require __DIR__.'/../vendor/autoload.php';
 
 AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
 
-include_once __DIR__.'/bootstrap.php.cache';
-
 return $loader;

--- a/app/console
+++ b/app/console
@@ -7,7 +7,7 @@
 
 set_time_limit(0);
 
-require_once __DIR__.'/bootstrap.php.cache';
+require_once __DIR__.'/autoload.php';
 require_once __DIR__.'/AppKernel.php';
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;

--- a/app/console
+++ b/app/console
@@ -1,18 +1,21 @@
 #!/usr/bin/env php
 <?php
 
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Debug\Debug;
+
 // if you don't want to setup permissions the proper way, just uncomment the following PHP line
 // read http://symfony.com/doc/current/book/installation.html#configuration-and-setup for more information
 //umask(0000);
 
 set_time_limit(0);
 
-require_once __DIR__.'/autoload.php';
+/**
+ * @var Composer\Autoload\ClassLoader $loader
+ */
+$loader = require __DIR__.'/../app/autoload.php';
 require_once __DIR__.'/AppKernel.php';
-
-use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Debug\Debug;
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
@@ -20,6 +23,8 @@ $debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(array('-
 
 if ($debug) {
     Debug::enable();
+} else {
+    include_once __DIR__.'/bootstrap.php.cache';
 }
 
 $kernel = new AppKernel($env, $debug);

--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -5,7 +5,7 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="bootstrap.php.cache"
+         bootstrap="autoload.php"
 >
     <testsuites>
         <testsuite name="Project Test Suite">

--- a/web/app.php
+++ b/web/app.php
@@ -3,7 +3,7 @@
 use Symfony\Component\ClassLoader\ApcClassLoader;
 use Symfony\Component\HttpFoundation\Request;
 
-$loader = require_once __DIR__.'/../app/bootstrap.php.cache';
+$loader = require_once __DIR__.'/../app/autoload.php';
 
 // Enable APC for autoloading to improve performance.
 // You should change the ApcClassLoader first argument to a unique prefix

--- a/web/app.php
+++ b/web/app.php
@@ -1,16 +1,19 @@
 <?php
 
-use Symfony\Component\ClassLoader\ApcClassLoader;
 use Symfony\Component\HttpFoundation\Request;
 
-$loader = require_once __DIR__.'/../app/autoload.php';
+/**
+ * @var Composer\Autoload\ClassLoader $loader
+ */
+$loader = require __DIR__.'/../app/autoload.php';
+include_once __DIR__.'/bootstrap.php.cache';
 
 // Enable APC for autoloading to improve performance.
 // You should change the ApcClassLoader first argument to a unique prefix
 // in order to prevent cache key conflicts with other applications
 // also using APC.
 /*
-$apcLoader = new ApcClassLoader(sha1(__FILE__), $loader);
+$apcLoader = new Symfony\Component\ClassLoader\ApcClassLoader(sha1(__FILE__), $loader);
 $loader->unregister();
 $apcLoader->register(true);
 */

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -18,7 +18,7 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
-$loader = require_once __DIR__.'/../app/bootstrap.php.cache';
+$loader = require_once __DIR__.'/../app/autoload.php';
 Debug::enable();
 
 require_once __DIR__.'/../app/AppKernel.php';

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -18,7 +18,10 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
-$loader = require_once __DIR__.'/../app/autoload.php';
+/**
+ * @var Composer\Autoload\ClassLoader $loader
+ */
+$loader = require __DIR__.'/../app/autoload.php';
 Debug::enable();
 
 require_once __DIR__.'/../app/AppKernel.php';


### PR DESCRIPTION
Fixes https://github.com/symfony/symfony-standard/issues/788#issuecomment-98993898 and https://github.com/symfony/symfony/pull/14776#issuecomment-106862443. 

- by default class aggregation is still used as it is probably beneficial by default for most people (no opcache at all or stats enabled)
- People that do not want to use the aggregation, can simply comment the line. They do not have to rewrite code. E.g. when using opcache with `opcache.validate_timestamps=0` in production there is no point in using the bootstrap.
- No debugging hell anymore as the class aggregation is only done in in no-debug mode
- All environments still use the same code path, i.e. load autoload first. The only difference is the inlusion of the aggregation.
- This way we can also simplify the bootstrap generation in the distribution bundle in the next major version of it.
- several imrprovements like using `require` instead of `require_once` for the autoloader to rely on the return value and `include_once` instead of `require_once` for the bootstrap as the app is also working without it