### PR TITLE
[WIP] commented usage of the templating sub-system

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -19,9 +19,8 @@ framework:
     csrf_protection: ~
     validation:      { enable_annotations: true }
     #serializer:      { enable_annotations: true }
-    templating:
-        engines: ['twig']
-        #assets_version: SomeVersionScheme
+    #templating:
+        #engines: ['php', 'twig']
     default_locale:  "%locale%"
     trusted_hosts:   ~
     trusted_proxies: ~


### PR DESCRIPTION
For 2.8, I'd like to promote a Twig-only approach. For this to happen:
- ~~We need to get rid of AsseticBundle (#860)~~
- We need to bump minimum versions of our deps (DoctrineBundle and SwitfmailerBundle) as a Twig-only approach only work when using the `@Some/.../....html.twig` notation
