### PR TITLE
Fix .gitignore for var dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,16 @@
 /app/config/parameters.yml
 /build/
 /phpunit.xml
-/var/
+/var/*
+!/var/cache
+/var/cache/*
 !var/cache/.gitkeep
+!/var/logs
+/var/logs/*
 !var/logs/.gitkeep
+!/var/sessions
+/var/sessions/*
 !var/sessions/.gitkeep
+!var/SymfonyRequirements.php
 /vendor/
 /web/bundles/


### PR DESCRIPTION
Yeah, it's actually pretty ugly, but AFAIK, it's the only way to keep the whole `var/` directory ignored, except those specific files in subdirectories.
Also, since the recently merged https://github.com/symfony/symfony-standard/pull/857, `SymfonyRequirements.php` is being ignored.