### PR TITLE
Update phpunit configuration

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -11,6 +11,7 @@
         <testsuite name="Project Test Suite">
             <directory>../src/*/*Bundle/Tests</directory>
             <directory>../src/*/Bundle/*Bundle/Tests</directory>
+            <directory>../src/*Bundle/Tests</directory>
         </testsuite>
     </testsuites>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Doc fix?      | no
| New docs?     | no
| Applies to    | 2.3
| Fixed tickets | #865

Fix a problem since the bundle without vendor name directly
inside the src directory are not going to be tested.
