### PR TITLE
Autoload the AppKernel using Composer

### DIFF
--- a/app/AppCache.php
+++ b/app/AppCache.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once __DIR__.'/AppKernel.php';
-
 use Symfony\Bundle\FrameworkBundle\HttpCache\HttpCache;
 
 class AppCache extends HttpCache

--- a/app/console
+++ b/app/console
@@ -15,7 +15,6 @@ set_time_limit(0);
  * @var Composer\Autoload\ClassLoader $loader
  */
 $loader = require __DIR__.'/../app/autoload.php';
-require_once __DIR__.'/AppKernel.php';
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "type": "project",
     "description": "The \"Symfony Standard Edition\" distribution",
     "autoload": {
-        "psr-4": { "": "src/" }
+        "psr-4": { "": "src/" },
+        "files": [ "app/AppKernel.php" ]
     },
     "require": {
         "php": ">=5.3.9",

--- a/web/app.php
+++ b/web/app.php
@@ -18,7 +18,6 @@ $loader->unregister();
 $apcLoader->register(true);
 */
 
-require_once __DIR__.'/../app/AppKernel.php';
 //require_once __DIR__.'/../app/AppCache.php';
 
 $kernel = new AppKernel('prod', false);

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -24,8 +24,6 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
 $loader = require __DIR__.'/../app/autoload.php';
 Debug::enable();
 
-require_once __DIR__.'/../app/AppKernel.php';
-
 $kernel = new AppKernel('dev', true);
 $kernel->loadClassCache();
 $request = Request::createFromGlobals();


### PR DESCRIPTION
Fixes #868

Using Composer to load the AppKernel means we don't have to manually include it in all the entry points of the application.