### PR TITLE
Add iconv to requirements

### DIFF
--- a/app/SymfonyRequirements.php
+++ b/app/SymfonyRequirements.php
@@ -447,6 +447,12 @@ class SymfonyRequirements extends RequirementCollection
         }
 
         $this->addRequirement(
+            function_exists('iconv'),
+            'iconv() must be available',
+            'Install and enable the <strong>iconv</strong> extension.'
+        );
+
+        $this->addRequirement(
             function_exists('json_encode'),
             'json_encode() must be available',
             'Install and enable the <strong>JSON</strong> extension.'


### PR DESCRIPTION
ext-iconv is already built by default into php since years (same as ext-json). Nobody has seen a php without iconv since years :) If we agree on this, then I could remove the iconv shim from https://github.com/symfony/symfony/pull/16240 and we could write code relying on `iconv*()` the same way we do for `json_encode`: without thinking about the function existence.