### PR TITLE
Make sure tests are run with full error reporting

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -7,6 +7,10 @@
          colors="true"
          bootstrap="bootstrap.php.cache"
 >
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>../src/*/*Bundle/Tests</directory>


### PR DESCRIPTION
This is also done in all symfony components. It makes sure that tests report all errors and warnings including strict ones.
Often this is not the case otherwise (because it's not part of the php defaults). The other advantage is that it makes tests more equal in PHP 5 and PHP 7. PHP  7 removed strict errors and changed them to warnings or notices. So in PHP 7 those errors might cause failures but they do not cause failures in PHP 5 when strict is ignored.