### PR TITLE
csrf_protection is now under framework.form instead of framework

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -15,8 +15,8 @@ framework:
     router:
         resource: "%kernel.root_dir%/config/routing.yml"
         strict_requirements: ~
-    form:            ~
-    csrf_protection: ~
+    form:
+        csrf_protection: ~
     validation:      { enable_annotations: true }
     #serializer:      { enable_annotations: true }
     templating:


### PR DESCRIPTION
Unrecognized option "csrf_protection" under "framework" was triggered when installing master version of this repository