### PR TITLE
Add phpunit-bridge to handle deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "incenteev/composer-parameter-handler": "~2.0"
     },
     "require-dev": {
-        "sensio/generator-bundle": "~2.3"
+        "sensio/generator-bundle": "~2.3",
+        "symfony/phpunit-bridge": "~2.7"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
Even though the standard-edition itself doesn't/shouldn't trigger deprecations, the phpunit bridge should still be included by default as developers will have to deal with deprecations sooner or later anyway (and they could even come from outside of symfony).

I targeted the 2.7 branch because that is where the phpunit-bridge was released and where symfony added deprecation warnings.