### PR TITLE
Use Kernel::getEnvironment() to keep consistency

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -35,7 +35,7 @@ class AppKernel extends Kernel
 
     public function getCacheDir()
     {
-        return dirname(__DIR__).'/var/cache/'.$this->environment;
+        return dirname(__DIR__).'/var/cache/'.$this->getEnvironment();
     }
 
     public function getLogDir()


### PR DESCRIPTION
Hi there!

The PR #850 introduced the use of the variable `$this->environment` to get the environment, but we already use the method `Kernel::getEnvironment()`, this PR fixes this to keep consistency.

Please review this before the Symfony 3.0 release.