### PR TITLE
Move the placeholder for assets version in config.yml

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -21,7 +21,6 @@ framework:
     #serializer:      { enable_annotations: true }
     templating:
         engines: ['twig']
-        #assets_version: SomeVersionScheme
     default_locale:  "%locale%"
     trusted_hosts:   ~
     trusted_proxies: ~
@@ -32,6 +31,7 @@ framework:
     fragments:       ~
     http_method_override: true
     assets: ~
+        #version: SomeVersionScheme
 
 # Twig Configuration
 twig:

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -30,8 +30,7 @@ framework:
         save_path:   "%kernel.root_dir%/../var/sessions/%kernel.environment%"
     fragments:       ~
     http_method_override: true
-    assets: ~
-        #version: SomeVersionScheme
+    assets:          ~
 
 # Twig Configuration
 twig:


### PR DESCRIPTION
Uncommenting ’#assets_version: SomeVersionScheme’ will cause an exception in Symfony 2.7+ The parameter was moved to framework -> asserts.