### PR TITLE
remove security-acl from dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "doctrine/orm": "~2.5@dev",
         "doctrine/doctrine-bundle": "~1.6@dev",
         "doctrine/doctrine-cache-bundle": "~1.2@dev",
-        "symfony/security-acl": "~3.0@dev",
         "symfony/swiftmailer-bundle": "~2.3",
         "symfony/monolog-bundle": "~2.8",
         "sensio/distribution-bundle": "~5.0",


### PR DESCRIPTION
I guess it was just added in https://github.com/symfony/symfony-standard/commit/82658ac4a1c5735d044f5b805761bb33aa5b15a1 to resolve unstable dependecies which should not be required anymore with https://github.com/doctrine/DoctrineCacheBundle/pull/77