### PR TITLE
Use proper autoloading for the kernel rather than file inclusion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "The \"Symfony Standard Edition\" distribution",
     "autoload": {
         "psr-4": { "": "src/" },
-        "files": [ "app/AppKernel.php" ]
+        "classmap": [ "app/AppKernel.php", "app/AppCache.php" ]
     },
     "require": {
         "php": ">=5.3.9",

--- a/web/app.php
+++ b/web/app.php
@@ -18,8 +18,6 @@ $loader->unregister();
 $apcLoader->register(true);
 */
 
-//require_once __DIR__.'/../app/AppCache.php';
-
 $kernel = new AppKernel('prod', false);
 $kernel->loadClassCache();
 //$kernel = new AppCache($kernel);


### PR DESCRIPTION
This allows to register the autoloading for AppCache too, making the diff smaller when wanting to use it.