### PR TITLE
fix ignored session save_path

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -26,8 +26,7 @@ framework:
     trusted_hosts:   ~
     trusted_proxies: ~
     session:
-        # handler_id set to null will use default session handler from php.ini
-        handler_id:  ~
+        handler_id:  session.handler.native_file
         save_path:   "%kernel.root_dir%/../var/sessions/%kernel.environment%"
     fragments:       ~
     http_method_override: true


### PR DESCRIPTION
fixes symfony/symfony#16898

do not use php.ini session handler but native file to actually use save_path config

When handler_id is null it uses the Native one, but that does not set the save_path. So we need to use https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php instead (which is the default configuration).