### PR TITLE
ignore event and doctrine logs in console

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -21,18 +21,7 @@ monolog:
         console:
             type:   console
             bubble: false
-            verbosity_levels:
-                VERBOSITY_VERBOSE: INFO
-                VERBOSITY_VERY_VERBOSE: DEBUG
-            channels: ["!doctrine"]
-        console_very_verbose:
-            type:   console
-            bubble: false
-            verbosity_levels:
-                VERBOSITY_VERBOSE: NOTICE
-                VERBOSITY_VERY_VERBOSE: NOTICE
-                VERBOSITY_DEBUG: DEBUG
-            channels: ["doctrine"]
+            channels: [!event, !doctrine]
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration
         #firephp:


### PR DESCRIPTION
Follow up on #908 to also ignore event logs in console. And simplify #707 to just ignore doctrine logs as well. #707 was not good because it creates inconsistencies between prod and dev environment. I.e. `-vv` has different result in prod and dev environment because the verbosity_level map is different which is really unexpected if you want to process stderr log in prod environment but they are not there.

So this gets rid these messages when running `app/console -vvv`

```
[2015-12-15 16:40:04] event.DEBUG: Notified event "console.command" to listener "Symfony\Component\HttpKernel\EventListener\DebugHandlersListener::configure". [] []
[2015-12-15 16:40:04] event.DEBUG: Notified event "console.command" to listener "Symfony\Bridge\Monolog\Handler\ConsoleHandler::onCommand". [] []
```