### PR TITLE
Use the getRootDir method instead of __DIR__

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -35,12 +35,12 @@ class AppKernel extends Kernel
 
     public function getCacheDir()
     {
-        return dirname(__DIR__).'/var/cache/'.$this->getEnvironment();
+        return dirname($this->getRootDir()).'/var/cache/'.$this->getEnvironment();
     }
 
     public function getLogDir()
     {
-        return dirname(__DIR__).'/var/logs';
+        return dirname($this->getRootDir()).'/var/logs';
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)


### PR DESCRIPTION
Hi,

I think it would be better to use the method ``getRootDir()``, what do you think about it?