### PR TITLE
use another method to provide more understandable content to getRootDir, ...

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -30,17 +30,22 @@ class AppKernel extends Kernel
 
     public function getRootDir()
     {
-        return __DIR__;
+        return $this->getProjectDir().'/app';
     }
 
     public function getCacheDir()
     {
-        return dirname(__DIR__).'/var/cache/'.$this->getEnvironment();
+        return $this->getProjectDir().'/var/cache/'.$this->getEnvironment();
     }
 
     public function getLogDir()
     {
-        return dirname(__DIR__).'/var/logs';
+        return $this->getProjectDir().'/var/logs';
+    }
+
+    protected function getProjectDir()
+    {
+        return dirname(__DIR__);
     }
 
     public function registerContainerConfiguration(LoaderInterface $loader)


### PR DESCRIPTION
… getCacheDir and getLogDir

This is the proposition I made on the last comment of the closed PR #914 

It provide more understandable content to the ``get*Dir()`` methods.