### PR TITLE
[RFC][DX] Add test front controller

### DIFF
--- a/web/app_test.php
+++ b/web/app_test.php
@@ -1,0 +1,34 @@
+
+<?php
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Debug\Debug;
+
+
+// If you don't want to setup permissions the proper way, just uncomment the following PHP line
+// read http://symfony.com/doc/current/book/installation.html#checking-symfony-application-configuration-and-setup
+// for more information
+//umask(0000);
+
+// This check prevents access to debug front controllers that are deployed by accident to production servers.
+// Feel free to remove this, extend it, or make something more sophisticated.
+if (isset($_SERVER['HTTP_CLIENT_IP'])
+    || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
+    || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1')) || php_sapi_name() === 'cli-server')
+) {
+    header('HTTP/1.0 403 Forbidden');
+    exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
+}
+
+/**
+ * @var Composer\Autoload\ClassLoader $loader
+ */
+$loader = require __DIR__.'/../app/autoload.php';
+Debug::enable();
+
+$kernel = new AppKernel('test', true);
+$kernel->loadClassCache();
+$request = Request::createFromGlobals();
+$response = $kernel->handle($request);
+$response->send();
+$kernel->terminate($request, $response);


### PR DESCRIPTION
Hello,

I suggest to add this new front controller because if you try to use `php bin/console server:run -e=test` you're website doesn't work (blank page) and the error is not obvious at all ! See:

```
[2016-01-03 02:15:25] php.DEBUG: fsockopen(): unable to connect to 127.0.0.1:8000 (Connection refused) {"type":2,"file":"/.../vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Command/ServerCommand.php","line":59,"level":28928} []
```

I lost some time searching for the reason, and as symfony core supports test env by default, the standard edition should support it too.

I put the same "security" inside the app_test file (that is in the same way bypassable), for similar reasons.

Hope you'll agree.