### PR TITLE
Update `.gitignore` with rules for `bin` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /app/config/parameters.yml
 /build/
+/bin/*
+!/bin/console
+!/bin/symfony_requirements
 /phpunit.xml
 /var/*
 !/var/cache


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

This allows to keep track of `bin/console` while leaves the rest of the directory's
content out of SCM, which is often generated by composer.