### PR TITLE
Added empty disallow field to robots.txt to comply with the Robot Exclusion Standard

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -2,3 +2,4 @@
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
 User-agent: *
+Disallow:


### PR DESCRIPTION
Actually a single tool: http://tool.motoricerca.info/robots-checker.phtml

And [this robotstxt.org page](http://www.robotstxt.org/orig.html#format) refers to this in these two sentences:

> The record starts with one or more User-agent lines, followed by one or more Disallow lines, as detailed below.

<!-- -->
> At least one Disallow field needs to be present in a record.

Hence Disallow field is needed because User-agent field exists.

I think commit message should be changed to something like "Added empty disallow field to robots.txt comply with Robot Exclusion Standard"