### PR TITLE
Properly lock down app_dev.php

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -12,7 +12,7 @@ use Symfony\Component\Debug\Debug;
 // Feel free to remove this, extend it, or make something more sophisticated.
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', 'fe80::1', '::1']) || php_sapi_name() === 'cli-server')
+    || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1']) || php_sapi_name() === 'cli-server')
 ) {
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');


### PR DESCRIPTION
Currently, web/app_dev.php in the symfony-standard package limits requests to those coming from CLI and unproxied localhost.

This prevents an attacker to execute this file in a production environment.

IPv4 localhost requests can come from 127.0.0.0/8, so the current check is actually a little bit too restrictive, but safe.

IPv6 localhost requests come from ::1/128.

The address fe80::1, however, is a link-local IPv6 address like any other. Anyone in the local network can take it and communicate with it. Therefore, it does not belong here.