### PR TITLE
[Monolog] Console handler don't bubble anymore

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -20,7 +20,6 @@ monolog:
             channels: [!event]
         console:
             type:   console
-            bubble: false
             channels: [!event, !doctrine]
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

see https://github.com/symfony/symfony-standard/pull/557#discussion_r52014052 for more information