### PR TITLE
Raising required PHP version for Symfony3 to 5.5.9

### DIFF
--- a/var/SymfonyRequirements.php
+++ b/var/SymfonyRequirements.php
@@ -376,7 +376,7 @@ class RequirementCollection implements IteratorAggregate
  */
 class SymfonyRequirements extends RequirementCollection
 {
-    const REQUIRED_PHP_VERSION = '5.3.3';
+    const REQUIRED_PHP_VERSION = '5.5.9';
 
     /**
      * Constructor that initializes the requirements.


### PR DESCRIPTION
Hi,

not sure why but required PHP version in `var/SymfonyRequirements.php` is still 5.3.3.
This value is important as is used by e.g. symfony installer for checking sysstem requirements and it's important from DX perspective (See issue https://github.com/symfony/symfony-installer/issues/239)

This pull request raise the minimum PHP version to 5.5.9 according to http://symfony.com/doc/current/reference/requirements.html

JZ
