### PR TITLE
Updating symfony/phpunit-bridge version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",
-        "symfony/phpunit-bridge": "^2.7|^3.0"
+        "symfony/phpunit-bridge": "^3.0"
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",
-        "symfony/phpunit-bridge": "^2.7"
+        "symfony/phpunit-bridge": "^2.7|^3.0"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
I recently installed Symfony 3.0.2, done a `composer update` and discovered (using vinkla/climb) that symfony/phpunit-bridge couldn't be updated to the latest major version. This should make the upgrade immediately executable on a fresh install.

I didn't update the lock because v3 increases the minimum PHP version to 5.5.9, so this remains backward compatible with older PHP versions.