### PR TITLE
Require ocramius/proxy-manager ^1.0 - 2.0 requires PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "symfony/monolog-bundle": "^2.8",
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^3.0.2",
-        "incenteev/composer-parameter-handler": "^2.0"
+        "incenteev/composer-parameter-handler": "^2.0",
+        "ocramius/proxy-manager": "^1.0"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",


### PR DESCRIPTION
ocramius/proxy-manager 2.0 requires PHP 7 so by default this project should require ^1.0 to not bump the dependency to PHP 7. If someone installs it on a PHP 7 machine and then wants to deploy it on PHP 5.5/5.6 it will fail. Only noticed this because I got an error on our build server after locally updating to 2.0 and pushing the changes.