### PR TITLE
Do security:check after installing or upgrading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget",
-            "bin/console security:check -q || app/console security:check --ansi || true"
+            "CHECK_OUTPUT=`bin/console security:check --ansi` && echo 'No known vulnerabilities found in vendors' || echo \"$CHECK_OUTPUT\""
         ],
         "post-update-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
@@ -43,7 +43,7 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget",
-            "bin/console security:check -q || app/console security:check --ansi || true"
+            "CHECK_OUTPUT=`bin/console security:check --ansi` && echo 'No known vulnerabilities found in vendors' || echo \"$CHECK_OUTPUT\""
         ]
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget",
+            "app/console security:check -q || app/console security:check --ansi || true"
         ],
         "post-update-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
@@ -41,7 +42,8 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
+            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget",
+            "app/console security:check -q || app/console security:check --ansi || true"
         ]
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget",
-            "app/console security:check -q || app/console security:check --ansi || true"
+            "bin/console security:check -q || app/console security:check --ansi || true"
         ],
         "post-update-cmd": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
@@ -43,7 +43,7 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget",
-            "app/console security:check -q || app/console security:check --ansi || true"
+            "bin/console security:check -q || app/console security:check --ansi || true"
         ]
     },
     "config": {


### PR DESCRIPTION
Compared to [adding the `roave/security-advisories` meta-package](https://github.com/symfony/symfony-standard/pull/760):
- It's output is much nicer
- It runs on any install, not just update, so you are more likely to
  get the warning earlier
- It's just a warning - it doesn't block you carrying on with
  upgrading / installing other things

I had a situation where a not-very-critical security error meant that
roave blocked me upgrading other packages, some of which had more
important issues to think about.
