### PR TITLE
dont hint the usage of the ApcuClassLoader anymore

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -1,17 +1,8 @@
 <?php
 
-use Symfony\Component\ClassLoader\ApcClassLoader;
 use Symfony\Component\HttpFoundation\Request;
 
 $loader = require_once __DIR__.'/../app/bootstrap.php.cache';
-
-// Use APC for autoloading to improve performance.
-// Change 'sf2' to a unique prefix in order to prevent cache key conflicts
-// with other applications also using APC.
-/*
-$loader = new ApcClassLoader('sf2', $loader);
-$loader->register(true);
-*/
 
 require_once __DIR__.'/../app/AppKernel.php';
 //require_once __DIR__.'/../app/AppCache.php';


### PR DESCRIPTION
the ApcuClassLoader isnt needed for PHP 5.6+ / PHP 7+ anymore, since
Composer can now dump a OPCache optimized static classmap, that has
similar performance characteristics

also the ApcuClassLoader could cause problems with memory fragmentation
for large apps

see https://github.com/composer/composer/pull/5174