### PR TITLE
Do not use validator.cache and serializer.cache anymore

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -2,10 +2,8 @@ imports:
     - { resource: config.yml }
 
 #framework:
-#    validation:
-#        cache: validator.mapping.cache.doctrine.apc
-#    serializer:
-#        cache: serializer.mapping.cache.apc
+#    cache:
+#        system: cache.adapter.apcu
 
 #doctrine:
 #    orm:


### PR DESCRIPTION
``framework.serializer.cache`` has been deprecated in https://github.com/symfony/symfony/pull/18630 in favor of the new caching system.

see https://github.com/symfony/symfony/pull/18630