### PR TITLE
Removing the symfony-tests-dir composer extra config - it's not used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,6 @@
         "symfony-bin-dir": "bin",
         "symfony-var-dir": "var",
         "symfony-web-dir": "web",
-        "symfony-tests-dir": "tests",
         "symfony-assets-install": "relative",
         "incenteev-parameters": {
             "file": "app/config/parameters.yml"


### PR DESCRIPTION
This was originally proposed for sensiolabs/SensioGeneratorBundle#416 (in #862), but I'm proposing to solve that in a simpler way: sensiolabs/SensioGeneratorBundle#494

Thanks!