### PR TITLE
Console should not accept an empty --env option

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -17,7 +17,7 @@ set_time_limit(0);
 $loader = require __DIR__.'/../app/autoload.php';
 
 $input = new ArgvInput();
-$env = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: 'dev');
+$env = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV')) ?: 'dev';
 $debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(['--no-debug', '']) && $env !== 'prod';
 
 if ($debug) {


### PR DESCRIPTION
Now, if you try to run `bin/console --env`, it throws an exception:

    [InvalidArgumentException]
    The file "/path/to/app/app/config/config_.yml" does not exist.