### PR TITLE
Filter only private IP allowed

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -12,7 +12,8 @@ use Symfony\Component\Debug\Debug;
 // Feel free to remove this, extend it, or make something more sophisticated.
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', 'fe80::1', '::1')) || php_sapi_name() === 'cli-server')
+    || !(false === filter_var(@$_SERVER['REMOTE_ADDR'], FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)
+        || 'cli-server' === php_sapi_name())
 ) {
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');


### PR DESCRIPTION
fixing to allow access from private IP to app_dev.php, including when using docker for Mac that use virtualbox as docker-machine. the machine IP like 192.168.99.100 but is still private IP.

but using this condition other people in LAN also can access the app_dev.php
