### PR TITLE
Change inline var PHPDoc syntax

### DIFF
--- a/app/autoload.php
+++ b/app/autoload.php
@@ -3,9 +3,7 @@
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Composer\Autoload\ClassLoader;
 
-/**
- * @var ClassLoader $loader
- */
+/** @var ClassLoader $loader */
 $loader = require __DIR__.'/../vendor/autoload.php';
 
 AnnotationRegistry::registerLoader(array($loader, 'loadClass'));

--- a/app/console
+++ b/app/console
@@ -11,9 +11,7 @@ use Symfony\Component\Debug\Debug;
 
 set_time_limit(0);
 
-/**
- * @var Composer\Autoload\ClassLoader $loader
- */
+/** @var \Composer\Autoload\ClassLoader $loader */
 $loader = require __DIR__.'/autoload.php';
 
 $input = new ArgvInput();

--- a/web/app.php
+++ b/web/app.php
@@ -2,9 +2,7 @@
 
 use Symfony\Component\HttpFoundation\Request;
 
-/**
- * @var Composer\Autoload\ClassLoader
- */
+/** @var \Composer\Autoload\ClassLoader $loader */
 $loader = require __DIR__.'/../app/autoload.php';
 include_once __DIR__.'/../app/bootstrap.php.cache';
 

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -18,9 +18,7 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
-/**
- * @var Composer\Autoload\ClassLoader $loader
- */
+/** @var \Composer\Autoload\ClassLoader $loader */
 $loader = require __DIR__.'/../app/autoload.php';
 Debug::enable();
 


### PR DESCRIPTION
See https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#722-var

(refer to the [examples](https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#examples-21))

Related previous PR: #571 (but there was no standard for inline `@var` at the time)