### PR TITLE
Use PHP's native session handler in dev environment

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -5,6 +5,8 @@ framework:
     router:
         resource: "%kernel.root_dir%/config/routing_dev.yml"
         strict_requirements: true
+    session:
+        handler_id:  ~
     profiler: { only_exceptions: false }
 
 web_profiler:


### PR DESCRIPTION
Using the native file session handler with a save path inside the project directory is causing a lot of problems, particularly for Vagrant environments with shared/NFS folders.

I suggest defaulting to PHP's native session handler at least for the development environment.