### PR TITLE
Fix invalid links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ released under the MIT or BSD license.
 
 Enjoy!
 
-[1]:  https://symfony.com/doc/3.0/book/installation.html
+[1]:  https://symfony.com/doc/3.1/setup.html
 [6]:  https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/index.html
-[7]:  https://symfony.com/doc/3.0/book/doctrine.html
-[8]:  https://symfony.com/doc/3.0/book/templating.html
-[9]:  https://symfony.com/doc/3.0/book/security.html
-[10]: https://symfony.com/doc/3.0/cookbook/email.html
-[11]: https://symfony.com/doc/3.0/cookbook/logging/monolog.html
-[13]: https://symfony.com/doc/3.0/bundles/SensioGeneratorBundle/index.html
+[7]:  https://symfony.com/doc/3.1/doctrine.html
+[8]:  https://symfony.com/doc/3.1/templating.html
+[9]:  https://symfony.com/doc/3.1/security.html
+[10]: https://symfony.com/doc/3.1/email.html
+[11]: https://symfony.com/doc/3.1/logging.html
+[13]: https://symfony.com/doc/current/bundles/SensioGeneratorBundle/index.html


### PR DESCRIPTION
https://symfony.com/doc/3.0/book/installation.html

![page-not-found](https://cloud.githubusercontent.com/assets/2028198/20152614/eb1e9054-a68c-11e6-80bb-a83e4af94855.png)

The changes were made based on recent documentation structure.
