### PR TITLE
Don't load class cache and bootstrap file on php 7

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -4,10 +4,14 @@ use Symfony\Component\HttpFoundation\Request;
 
 /** @var \Composer\Autoload\ClassLoader $loader */
 $loader = require __DIR__.'/../app/autoload.php';
-include_once __DIR__.'/../var/bootstrap.php.cache';
+if (PHP_VERSION_ID < 70000) {
+    include_once __DIR__.'/../var/bootstrap.php.cache';
+}
 
 $kernel = new AppKernel('prod', false);
-$kernel->loadClassCache();
+if (PHP_VERSION_ID < 70000) {
+    $kernel->loadClassCache();
+}
 //$kernel = new AppCache($kernel);
 
 // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -23,7 +23,9 @@ $loader = require __DIR__.'/../app/autoload.php';
 Debug::enable();
 
 $kernel = new AppKernel('dev', true);
-$kernel->loadClassCache();
+if (PHP_VERSION_ID < 70000) {
+    $kernel->loadClassCache();
+}
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
As discussed in symfony/symfony#20668, the class cache features should be deprecated. Since the class cache and the bootstrap file are still useful on php 5, we load them only when running on php 5.

A future php-7-only release of Symfony Standard should remove those blocks completely.