### PR TITLE
Update sample sqlite path according to symfony 3 directory structure

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -49,7 +49,7 @@ doctrine:
         charset:  UTF8
         # if using pdo_sqlite as your database driver:
         #   1. add the path in parameters.yml
-        #     e.g. database_path: "%kernel.root_dir%/data/data.db3"
+        #     e.g. database_path: "%kernel.root_dir%/../var/data/data.sqlite"
         #   2. Uncomment database_path in parameters.yml.dist
         #   3. Uncomment next line:
         #     path:     "%database_path%"


### PR DESCRIPTION
I think sqlite databases should be stored in `var/` as it is storage file