### PR TITLE
Fix ability to uncomment the sqlite path easily

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -54,7 +54,7 @@ doctrine:
         #     e.g. database_path: "%kernel.root_dir%/data/data.db3"
         #   2. Uncomment database_path in parameters.yml.dist
         #   3. Uncomment next line:
-        #     path:     "%database_path%"
+        #path:     "%database_path%"
 
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"


### PR DESCRIPTION
So both key and value are aligned to the previous config line using the uncomment shortcut of IDEs