### PR TITLE
[Fix] Notice: A non well formed numeric value encountered

### DIFF
--- a/var/SymfonyRequirements.php
+++ b/var/SymfonyRequirements.php
@@ -780,7 +780,13 @@ class SymfonyRequirements extends RequirementCollection
     {
         $size = ini_get('realpath_cache_size');
         $size = trim($size);
-        $unit = strtolower(substr($size, -1, 1));
+        $unit = '';
+        
+        if (!ctype_digit($size)) {
+            $unit = strtolower(substr($size, -1, 1));
+            $size = (int) substr($size, 0, -1);
+        }
+        
         switch ($unit) {
             case 'g':
                 return $size * 1024 * 1024 * 1024;


### PR DESCRIPTION
realpath_cache_size can be with or without unit. 
Remove last character ($unit) from string $size if not all characters in $size are numerical.