### PR TITLE
Update symfony/monolog-bundle to 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "doctrine/doctrine-bundle": "~1.4",
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3,>=2.3.10",
-        "symfony/monolog-bundle": "~2.12",
+        "symfony/monolog-bundle": "^3.0.2",
         "sensio/distribution-bundle": "~4.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "~2.0"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "doctrine/doctrine-bundle": "~1.4",
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3,>=2.3.10",
-        "symfony/monolog-bundle": "~2.11.3",
+        "symfony/monolog-bundle": "~2.12",
         "sensio/distribution-bundle": "~4.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "~2.0"


### PR DESCRIPTION
Currently when using Symfony >= 2.8.14 with monolog-bundle 2.11.3, no logs are shown in the profiler. When using monolog-bundle 2.12, the logs appear again.

I haven't tested on 2.7 yet, but this change should work fine for 2.7 as well.

Related: symfony/symfony#21014
