### PR TITLE
Added .web-server-pid to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.web-server-pid
 /app/config/parameters.yml
 /build/
 /phpunit.xml


### PR DESCRIPTION
This fixes:

```
>[{..}ithub.com/lyrixx/symfony-standard](server-log) git st
nothing to commit, working tree clean
>[{..}ithub.com/lyrixx/symfony-standard](server-log) bin/console server:start

                                                                                                                        
 [OK] Server listening on http://127.0.0.1:8001                                                                         
                                                                                                                        

>[{..}ithub.com/lyrixx/symfony-standard](server-log %) git st
Untracked files:
  (use "git add <file>..." to include in what will be committed)

        .web-server-pid

nothing added to commit but untracked files present (use "git add" to track)
```