### PR TITLE
Don't log console errors in console output

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -20,7 +20,7 @@ monolog:
             channels: [!event]
         console:
             type:   console
-            channels: [!event, !doctrine]
+            channels: [!event, !doctrine, !console]
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration
         #firephp:


### PR DESCRIPTION
Since https://github.com/symfony/symfony/pull/21003, console errors are logged, and since the `console` channel is not ignored by the monolog console handler, the log is written to stderr.

IMHO it's useless since the ran command already write the message into, it's just having two traces for the same error, which doesn't make sense to me. 

I propose to fix that.

__Before__
![before](http://image.prntscr.com/image/16a2773542ee4a0caeaf626b119d5c18.png)

__After__
![after](http://image.prntscr.com/image/facb6641ffdf4df5af90d203c6327fb5.png)

If one wants the trace, then one can run the command in verbose mode or look at its log file.