### PR TITLE
explicitly declare supported Twig versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "symfony/monolog-bundle": "^3.0.2",
         "sensio/distribution-bundle": "~4.0",
         "sensio/framework-extra-bundle": "^3.0.2",
+        "twig/twig": "^1.0||^2.0",
         "incenteev/composer-parameter-handler": "~2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Not being explicit which Twig versions the application supports mean
that users will get new major Twig releases when they become stable and
composer update is run. This can lead to undesired effects when the new
ajor release is breaking backwards compatibility.