### PR TITLE
Improve PSR-4 autoloading by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,9 @@
     "type": "project",
     "description": "The \"Symfony Standard Edition\" distribution",
     "autoload": {
-        "psr-4": { "": "src/" }
+        "psr-4": {
+            "AppBundle\\": "src/AppBundle"
+        }
     },
     "require": {
         "php": ">=5.3.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "bdde043c25314bfbc2727929457166a0",
+    "content-hash": "7179f4c120649326ae8dab4da26c6db9",
     "packages": [
         {
             "name": "doctrine/annotations",


### PR DESCRIPTION
TL;DR: (updated Marth 3rd)
Before, I proposed to use any optimization by default in `composer.json` (complementary to PSR-4 autoload for the AppBundle).

I took note of the different arguments and removed loaders optimization because it is not suitable for dev environments, but kept AppBundle PSR-4 explicit load because it encourages PSR-4 best practices of autoload.

--- 

As seen on symfony/symfony-demo#490 (and it's certainly a well-known issue for developers using PHP Inspections EA Extended plugin for PHPStorm), having empty namespaces in `psr-4` rules has an impact on performances.

Using this by default on the Standard Edition may encourage developers to add PSR-4 rules if they create new namespaces (for example if they want to create bundleless apps or other bundles, or components inside the same app, etc.).

What do you think about putting this in the SE?

Also, for best autoloading performances, it is recommended to use `classmap-authoritative` options (which adds `optimize-autoloader` implicitly). I added it in the `composer.json` but I'm not sure whether it's the best option to propose to Symfony newcomers (because `composer install` and `update` takes more time to execute).

For this have a question: should we recommend `classmap-authoritative` or `optimize-autoloader` (or nothing ❔) by default ?