### PR TITLE
Do not process psr_3 log messages, as it's now done by symfony.

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -20,6 +20,7 @@ monolog:
             channels: ['!event']
         console:
             type:   console
+            process_psr_3_messages: false
             channels: ['!event', '!doctrine', '!console']
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration

--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -19,3 +19,4 @@ monolog:
             level: debug
         console:
             type: console
+            process_psr_3_messages: false


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/pull/21705

Note: It's not an issue to let monolog doing it, but if monolog do it
symfony can not do it. The best experience is when symfony do it.

So let's disable it.