### PR TITLE
Fix sqlite db path in parameters.yml.dist

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -8,7 +8,7 @@ parameters:
     database_user: root
     database_password: ~
     # You should uncomment this if you want to use pdo_sqlite
-    #database_path: "%kernel.root_dir%/data.db3"
+    #database_path: '%kernel.root_dir%/../var/data/data.sqlite'
 
     mailer_transport: smtp
     mailer_host: 127.0.0.1


### PR DESCRIPTION
This should have been done in #1032. ~Adding the path to `.gitignore` was done on symfony-demo, I think we can do it here too.~