### PR TITLE
Replace static calls with actual commands in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,8 @@
         "symfony-scripts": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
-            "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
+            "@php bin/console cache:clear --ansi",
+            "@php bin/console assets:install web --symlink --relative --ansi",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"
         ],

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "symfony-scripts": [
             "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::buildBootstrap",
-            "@php bin/console cache:clear --ansi",
+            "@php bin/console cache:clear --no-warmup --ansi",
+            "@php bin/console cache:warmup --ansi",
             "@php bin/console assets:install web --symlink --relative --ansi",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::prepareDeploymentTarget"


### PR DESCRIPTION
Composer now supports using `@php` to run commands. I suggest using this feature in favor of some `ScriptHandler::{method}` calls. This will make changing commands' options and arguments easier.

Also split the `cache:clear` call.