### PR TITLE
Remove iconv as a recommendation as it is already a requirement

### DIFF
--- a/app/SymfonyRequirements.php
+++ b/app/SymfonyRequirements.php
@@ -632,12 +632,6 @@ class SymfonyRequirements extends RequirementCollection
         );
 
         $this->addRecommendation(
-            function_exists('iconv'),
-            'iconv() should be available',
-            'Install and enable the <strong>iconv</strong> extension.'
-        );
-
-        $this->addRecommendation(
             function_exists('utf8_decode'),
             'utf8_decode() should be available',
             'Install and enable the <strong>XML</strong> extension.'


### PR DESCRIPTION
It's already a requirement: https://github.com/symfony/symfony-standard/blob/2.7/app/SymfonyRequirements.php#L463-L467