### PR TITLE
Removed the "trusted_proxies" entry from config.yml

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -23,7 +23,6 @@ framework:
         engines: ['twig']
     default_locale: '%locale%'
     trusted_hosts: ~
-    trusted_proxies: ~
     session:
         # http://symfony.com/doc/current/reference/configuration/framework.html#handler-id
         handler_id:  session.handler.native_file


### PR DESCRIPTION
This commit fixes the following error:

```

  [InvalidArgumentException]
  The "framework.trusted_proxies" configuration key has been removed in
Symfony 3.3. Use the Request::setTrustedProxies() method in your front
controller instead.

```