### PR TITLE
Use symfony 3.3 features

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -4,6 +4,22 @@ parameters:
     #parameter_name: value
 
 services:
-    #service_name:
-    #    class: AppBundle\Directory\ClassName
-    #    arguments: ['@another_service_name', 'plain_value', '%parameter_name%']
+    # default configuration for services in *this* file
+    _defaults:
+        # automatically injects dependencies in your services
+        autowire: true
+        # automatically registers your services as commands, form types, etc.
+        autoconfigure: true
+        # this means you cannot fetch services directly from the container via $container->get()
+        # if you need to do this, you can override this setting on individual services
+        public: false
+
+    # loads services from whatever directories you want (you can add directories!)
+    # this creates a service per class whose id is the fully-qualified class name
+    AppBundle\:
+        resource: '../../src/AppBundle/{Command,Form,EventSubscriber,Twig,Security}'
+
+    AppBundle\Controller\:
+        resource: '../../src/AppBundle/Controller'
+        public: true
+        tags: ['controller.service_arguments']


### PR DESCRIPTION
With [Flex coming](https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.3/etc/packages/app.yaml) and [the refactoring of the docs](https://github.com/symfony/symfony-docs/pull/7807), I think we should push sf 3.3 di features and also begin to accustom people to sf 4.0 ideas.

ping @weaverryan 