### PR TITLE
remove deprecated %kernel.root_dir% from config.yml

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -13,7 +13,7 @@ framework:
     #translator: { fallbacks: ['%locale%'] }
     secret: '%secret%'
     router:
-        resource: '%kernel.root_dir%/config/routing.yml'
+        resource: '%kernel.project_dir%/../config/routing.yml'
         strict_requirements: ~
     form: ~
     csrf_protection: ~
@@ -26,7 +26,7 @@ framework:
     session:
         # http://symfony.com/doc/current/reference/configuration/framework.html#handler-id
         handler_id:  session.handler.native_file
-        save_path:   "%kernel.root_dir%/../var/sessions/%kernel.environment%"
+        save_path:   "%kernel.project_dir%/var/sessions/%kernel.environment%"
     fragments: ~
     http_method_override: true
     assets: ~

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -13,7 +13,7 @@ framework:
     #translator: { fallbacks: ['%locale%'] }
     secret: '%secret%'
     router:
-        resource: '%kernel.project_dir%/../config/routing.yml'
+        resource: '%kernel.project_dir%/app/config/routing.yml'
         strict_requirements: ~
     form: ~
     csrf_protection: ~


### PR DESCRIPTION
From UPGRADE-3.3.md:
"Deprecated the kernel.root_dir parameter. Use the new kernel.project_dir parameter instead."