### PR TITLE
Use PHP_SAPI instead of php_sapi_name()

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -12,7 +12,7 @@ use Symfony\Component\Debug\Debug;
 // Feel free to remove this, extend it, or make something more sophisticated.
 if (isset($_SERVER['HTTP_CLIENT_IP'])
     || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
-    || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', '::1')) || php_sapi_name() === 'cli-server')
+    || !(in_array(@$_SERVER['REMOTE_ADDR'], array('127.0.0.1', '::1')) || PHP_SAPI === 'cli-server')
 ) {
     header('HTTP/1.0 403 Forbidden');
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');


### PR DESCRIPTION
In Symfony code we only use PHP_SAPI and https://secure.php.net/manual/en/function.php-sapi-name.php says:

> Note:
> The PHP constant PHP_SAPI has the same value as php_sapi_name().