### PR TITLE
app.php and console: no need to declare $loader variable

### DIFF
--- a/app/console
+++ b/app/console
@@ -12,8 +12,7 @@ use Symfony\Component\Debug\Debug;
 
 set_time_limit(0);
 
-/** @var \Composer\Autoload\ClassLoader $loader */
-$loader = require __DIR__.'/autoload.php';
+require __DIR__.'/autoload.php';
 
 $input = new ArgvInput();
 $env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');

--- a/web/app.php
+++ b/web/app.php
@@ -2,8 +2,7 @@
 
 use Symfony\Component\HttpFoundation\Request;
 
-/** @var \Composer\Autoload\ClassLoader $loader */
-$loader = require __DIR__.'/../app/autoload.php';
+require __DIR__.'/../app/autoload.php';
 include_once __DIR__.'/../app/bootstrap.php.cache';
 
 $kernel = new AppKernel('prod', false);


### PR DESCRIPTION
The var isn't being used anywhere in the file(s).

Because of how "require" works,
$loader is still a global variable.