### PR TITLE
Use localhost by default for the server log socket.

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -27,7 +27,7 @@ monolog:
         server_log:
             type:   server_log
             process_psr_3_messages: false
-            host: 0:9911
+            host: localhost:9911
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration
         #firephp:


### PR DESCRIPTION
This fixes the server log on Windows, which is currently causing the dev environment to hang and become unusable:

https://github.com/symfony/symfony/issues/22712

The hostname "0" apparently doesn't work on Windows, but it does on Linux. Though I've honestly never seen "0" used in a connection string before. I figure localhost is the best default route to go. There is still the issue of the ServerLogHandler in the monolog bridge bundle where the underlying issue surfaced.

Basically since "0:9911" was not valid on Windows, the socket was never opened. Yet every time it would attempt to log to the socket again it would go through the same timeout period. Multiply that by all the times that gets called and you'll be waiting a while to get a response... 

Even though this change makes the dev environment usable on Windows, the Server Log handler still has a huge performance impact there. It takes almost 6-8x longer for a page to load in the dev environment now.