### PR TITLE
Use localhost for the server log handler.

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -27,7 +27,7 @@ monolog:
         server_log:
             type:   server_log
             process_psr_3_messages: false
-            host: 0:9911
+            host: localhost:9911
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration
         #firephp:


### PR DESCRIPTION
See: https://github.com/symfony/symfony-standard/pull/1077. Had to create this new PR to target 3.3 specifically.

This is to set the server log handler hostname to something that's resolvable under both Linux and Windows. I'm not sure if this should stick to localhost or 127.0.0.1 (which is used elsewhere, such as the defaults in the parameters file). Being set to 0 on Windows causes a DNS timeout in `stream_socket_client` which there doesn't seem to be any control over.