### PR TITLE
Replace localhost with 127.0.0.1

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -27,7 +27,7 @@ monolog:
         server_log:
             type:   server_log
             process_psr_3_messages: false
-            host: localhost:9911
+            host: 127.0.0.1:9911
         # uncomment to get logging in your browser
         # you may have to allow bigger header sizes in your Web server configuration
         #firephp:


### PR DESCRIPTION
Using IP address is more robust and we also refer to 127.0.0.1 in [parameters.yml.dist](https://github.com/symfony/symfony-standard/blob/3.3/app/config/parameters.yml.dist) - it will be more consistent with IP address for `server_log.host`.