### PR TITLE
Restore right autoload path in app_dev.php

### DIFF
--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -18,7 +18,7 @@ if (isset($_SERVER['HTTP_CLIENT_IP'])
     exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
 }
 
-require __DIR__.'/../app/autoload.php';
+require __DIR__.'/../vendor/autoload.php';
 Debug::enable();
 
 $kernel = new AppKernel('dev', true);


### PR DESCRIPTION
Sound like a mistake during https://github.com/symfony/symfony-standard/commit/39db2979b273a0b27470e702354f3383bf1bdcd7#diff-5f5343d10fae8e62eba1c31ba15d9dc5

Same change to report in 3.4 https://github.com/symfony/symfony-standard/blob/3.4/web/app_dev.php#L21