### PR TITLE
ignore node_modules folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.web-server-pid
 /app/config/parameters.yml
 /build/
+/node_modules/
 /phpunit.xml
 /var/*
 !/var/cache


### PR DESCRIPTION
Because now we have @symfony/webpack-encore for asset bundling, I believe the node_modules should be ignored by default.