### PR TITLE
Improve error message when ext-xml is not installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     },
     "require": {
         "php": ">=5.5.9",
+        "ext-xml": "*",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/orm": "^2.5",
         "incenteev/composer-parameter-handler": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "620010b4a6c5f00f26dd7a5230eff84d",
+    "content-hash": "faf693b88d06b53a50feaa7cebeb0e8d",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2372,7 +2372,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5.9"
+        "php": ">=5.5.9",
+        "ext-xml": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
Ran into this with a fresh installation of php from ondrej ppa on debian and the standard edition.

When I ran this composer install I got the following output:
```
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Generating autoload files
> Incenteev\ParameterHandler\ScriptHandler::buildParameters
Updating the "app/config/parameters.yml" file
> Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::buildBootstrap
> Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache
PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "DOMDocument" from the global namespace.
Did you forget a "use" statement? in /home/alex/repos/dummy/vendor/symfony/symfony/src/Symfony/Component/Config/Util/XmlUtils.php:52
Stack trace:
#0 /home/alex/repos/dummy/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php(368): Symfony\Component\Config\Util\XmlUtils::loadFile('/home/alex/repo...', Array)
#1 /home/alex/repos/dummy/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php(41): Symfony\Component\DependencyInjection\Loader\XmlFileLoader->parseFileToDOM('/home/alex/repo...')
#2 /home/alex/repos/dummy/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php(96): Symfony\Component\DependencyInjection\Loader\XmlFileLoader->load('web.xml')
#3 /home/alex/repos/dummy/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfig in /home/alex/repos/dummy/vendor/symfony/symfony/src/Symfony/Component/Config/Util/XmlUtils.php on line 52
Script Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache handling the symfony-scripts event terminated with an exception

                                                                                                                                                                                             
  [RuntimeException]                                                                                                                                                                         
  An error occurred when executing the "'cache:clear --no-warmup'" command:                                                                                                                  
  PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\ClassNotFoundException: Attempted to load class "DOMDocument" from the global namespace.                                      
  Did you forget a "use" statement? in /home/alex/repos/dummy/vendor/symfony/symfony/src/Symfony/Component/Config/Util/XmlUtils.php:52                                                       
  Stack trace:                                                                                                                                                                               
  #0 /home/alex/repos/dummy/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php(368): Symfony\Component\Config\Util\XmlUtils::loadFile('/home/alex/re  
  po...', Array)                                                                                                                                                                             
  #1 /home/alex/repos/dummy/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php(41): Symfony\Component\DependencyInjection\Loader\XmlFileLoader->pars  
  eFileToDOM('/home/alex/repo...')                                                                                                                                                           
  #2 /home/alex/repos/dummy/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php(96): Symfony\Component\DependencyInjection\Loader\XmlFileL  
  oader->load('web.xml')                                                                                                                                                                     
  #3 /home/alex/repos/dummy/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfig in /home/alex/repos/dummy/vendor/symfony/symfony/src/Symfony/Com  
  ponent/Config/Util/XmlUtils.php on line 52                                                                                                                                                 
                                                                                                                                                                                             

install [--prefer-source] [--prefer-dist] [--dry-run] [--dev] [--no-dev] [--no-custom-installers] [--no-autoloader] [--no-scripts] [--no-progress] [--no-suggest] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--ignore-platform-reqs] [--] [<packages>]...
```

Now it's changed to this, which should make the experience less painful to anyone getting started with symfony or php:

```
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested PHP extension ext-xml * is missing from your system. Install or enable PHP's xml extension.

```
