### PR TITLE
[RFC] Add command in bin for clearing cache even if environment is broken

### DIFF
--- a/bin/clear-cache
+++ b/bin/clear-cache
@@ -1,0 +1,33 @@
+#!/usr/bin/env php
+<?php
+
+$varName = 'var';
+$rootPath = dirname(__DIR__);
+$composerPath = $rootPath.'/composer.json';
+
+if (file_exists($composerPath) && is_readable($composerPath)) {
+    $composer = json_decode(file_get_contents($composerPath), JSON_OBJECT_AS_ARRAY);
+    if ($composer && isset($composer['extra']) && isset($composer['extra']['symfony-var-dir'])) {
+        $varName = $composer['extra']['symfony-var-dir'];
+    }
+}
+
+$cacheDir = $rootPath.'/'.$varName.'/cache';
+if (!is_dir($cacheDir) || !is_writable($cacheDir)) {
+    die (sprintf("Cache directory '%s' does not seem to exist or is not writable to the current user.\n", $cacheDir));
+}
+
+if ($argc > 1) {
+    $cacheDir .= '/' . $argv[1];
+    if (!is_dir($cacheDir) || !is_writable($cacheDir)) {
+        die (sprintf("Environment cache directory '%s' does not seem to exist or is not writable to the current user.\n", $cacheDir));
+    }
+}
+
+if ('/' === DIRECTORY_SEPARATOR) {
+    system('rm -rf '.escapeshellarg($cacheDir));
+} else {
+    system('rmdir /S /Q '.escapeshellarg($cacheDir));
+}
+
+die (sprintf("Cache directory '%s' successfully removed.\n", $cacheDir));


### PR DESCRIPTION
Follows the discussion at https://github.com/symfony/symfony/issues/23592

This command allows one to run `bin/clear-cache` or `bin/clear-cache <envName>` in any situation. It's consciously implemented als Plain Ole PHP since it is most commonly used to fix a temporary broken environment, in which the vendor directory or its packages may also well be (temporarily) broken. So no use in depending on `symfony/console` or 'symfony/process`.

If we do this the `clearCache` command in SensioDistributionBundle will also need to be patched afterwards, and some documentation changed.

Based on 3.3 as it deprecated `clear:cache` without `--no-warmup`, no use in adding it to older versions.