### PR TITLE
Show console log channel so that command runs with error code are visible

### DIFF
--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -21,7 +21,7 @@ monolog:
         console:
             type: console
             process_psr_3_messages: false
-            channels: ['!event', '!doctrine', '!console']
+            channels: ['!event', '!doctrine']
         # To follow logs in real time, execute the following command:
         # `bin/console server:log -vv`
         server_log:


### PR DESCRIPTION
I think that the change introduced in #1044 not such a clear cut case, just spent a lot of time finding why it is not shown any more. With the exception/error case I agree, that the log statement is superfluous, but that is not the case for error codes.

Imagine a command which signals success/failure by return codes (as is usual in CLI), then when you run it, you have no visible feedback on whether it was run successfully or not:

```
bin/console hello:world
```

with the logging for console not filtered out it would be much more user friendly:

```
bin/console hello:world
17:47:32 ERROR     [console] Command "hello:world" exited with code "123" ["command" => "hello:world","code" => 123] []
```
which is I think exactly the reason why the printing out logs in console feature was introduced.

---

To sum it up, I think not showing the logs in the error code case is more developer unfriendly than them being showed when not needed.

cc @chalasr 