### PR TITLE
Remove templating layer from standard edition

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -19,8 +19,6 @@ framework:
     csrf_protection: ~
     validation: { enable_annotations: true }
     #serializer: { enable_annotations: true }
-    templating:
-        engines: ['twig']
     default_locale: '%locale%'
     trusted_hosts: ~
     session:


### PR DESCRIPTION
Also works without it as `\Symfony\Bundle\FrameworkBundle\Controller\ControllerTrait::render` will just use twig directly then. Whether we deprecate or not deprecate the templating layer (https://github.com/symfony/symfony/pull/21036) we should still promote not to use it by default.