### PR TITLE
Added DataFixtures in Exclude Folders

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -20,7 +20,7 @@ services:
         resource: '../../src/AppBundle/*'
         # you can exclude directories or files
         # but if a service is unused, it's removed anyway
-        exclude: '../../src/AppBundle/{Entity,Repository,Tests}'
+        exclude: '../../src/AppBundle/{Entity,Repository,Tests,DataFixtures}'
 
     # controllers are imported separately to make sure they're public
     # and have a tag that allows actions to type-hint services


### PR DESCRIPTION
I added this folder because if you have DataFixtures in AppKernel in environment Dev mode, it returns error in the deploy when I apply --no-dev config. And we don't need autoload this folder.
So.. is a bug.