### PR TITLE
Improve the console script

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -15,8 +15,8 @@ set_time_limit(0);
 require __DIR__.'/../vendor/autoload.php';
 
 $input = new ArgvInput();
-$env = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: 'dev');
-$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(['--no-debug', '']) && $env !== 'prod';
+$env = $input->getParameterOption(['--env', '-e'], getenv('SYMFONY_ENV') ?: 'dev', true);
+$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption('--no-debug', true) && $env !== 'prod';
 
 if ($debug) {
     Debug::enable();


### PR DESCRIPTION
- look for the `--env` and `--no-debug` only before a `--` separator, to respect the support for `--`
- avoid passing an empty string as parameter option name (which would never match anyway, but causes php warning is some Symfony versions instead of being ignored silently, because of https://github.com/symfony/symfony/issues/26136).

Same change than https://github.com/symfony/recipes/pull/367