### PR TITLE
PHP files in the resources server error

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -20,7 +20,7 @@ services:
         resource: '../../src/AppBundle/*'
         # you can exclude directories or files
         # but if a service is unused, it's removed anyway
-        exclude: '../../src/AppBundle/{Entity,Repository,Tests}'
+        exclude: '../../src/AppBundle/{Entity,Repository,Resources,Tests}'
 
     # controllers are imported separately to make sure they're public
     # and have a tag that allows actions to type-hint services


### PR DESCRIPTION
When PHP files are in the `Resources` folder (e.g. when using the `PhpFileLoader`) the following exception is thrown:

> The autoloader expected class "AppBundle\Resources\config\services" to be defined in file "src/AppBundle/Resources/config/services.php". The file was found but the class was not in it, the class name or namespace probably has a typo in app/config/services.yml (which is being imported from "app/config/config.yml").

This modification excludes the `Resources` folder that is not supposed to have such classes.