### PR TITLE
Fix default timezone test

### DIFF
--- a/var/SymfonyRequirements.php
+++ b/var/SymfonyRequirements.php
@@ -448,15 +448,10 @@ class SymfonyRequirements extends RequirementCollection
         }
 
         if (false !== $requiredPhpVersion && version_compare($installedPhpVersion, $requiredPhpVersion, '>=')) {
-            $timezones = array();
-            foreach (DateTimeZone::listAbbreviations() as $abbreviations) {
-                foreach ($abbreviations as $abbreviation) {
-                    $timezones[$abbreviation['timezone_id']] = true;
-                }
-            }
+            $timezones = DateTimeZone::listIdentifiers();
 
             $this->addRequirement(
-                isset($timezones[@date_default_timezone_get()]),
+                in_array(@date_default_timezone_get(), $timezones, true),
                 sprintf('Configured default timezone "%s" must be supported by your installation of PHP', @date_default_timezone_get()),
                 'Your default timezone is not supported by PHP. Check for typos in your <strong>php.ini</strong> file and have a look at the list of deprecated timezones at <a href="http://php.net/manual/en/timezones.others.php">http://php.net/manual/en/timezones.others.php</a>.'
             );


### PR DESCRIPTION
symfony/symfony issue: [#26550](https://github.com/symfony/symfony/issues/26550)

Both my php.ini files have correct values for date.timezone var:

```
> php -i | grep "timezone"
Default timezone => America/Sao_Paulo
date.timezone => America/Sao_Paulo => America/Sao_Paulo
```

But Symfony 3.4 requirements test returning error:

```
> php test/bin/symfony_requirements
Configured default timezone "America/Sao_Paulo" must be supported
   by your installation of PHP
   > Your default timezone is not supported by PHP. Check for typos in
   > your php.ini file and have a look at the list of deprecated
   > timezones at http://php.net/manual/en/timezones.others.php.
```

But America/Sao_Paulo isn't deprecated.